### PR TITLE
fix: Add PostgreSQL to Nix Flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,7 @@
               rust-toolchain
               pre-commit
               protobuf
+              postgresql
               direnv
               self.packages.${system}.irust
             ]


### PR DESCRIPTION
# Description

PostgreSQL required in Nix Flake to get a reproducable build

## Link to issue

N/A

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test plan (required)

> Demonstrate the code is solid. Which commands did you test with and what are the expected results?

Run `nix develop && cargo build`

> Which tests have you added or updated? Do the tests cover all of the changes included in this PR?

N/A

## Screenshots/Screencaps

### Before

```
"CoreFoundation" "-framework" "Security" "-liconv" "-lSystem" "-lc" "-lm" "-L" "/nix/store/k1gfg33vvjzz1gamjjf00pw7q4dmdfqq-rust-default-1.71.0-nightly-2023-04-24/lib/rustlib/aarch64-apple-darwin/lib" "-o" "/Users/expede/Documents/Work/Fission/fission-server/target/debug/deps/fission_server_app-71325f1c108c2380" "-Wl,-dead_strip" "-nodefaultlibs"
  = note: ld: library not found for -lpq
          clang-11: error: linker command failed with exit code 1 (use -v to see invocation)


error: could not compile `fission-server` (bin "fission-server-app") due to previous error
```

### After

```
»  cargo build
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /Users/expede/Documents/Work/Fission/fission-server/fission-server/Cargo.toml
workspace: /Users/expede/Documents/Work/Fission/fission-server/Cargo.toml
   Compiling fission-server v0.1.0 (/Users/expede/Documents/Work/Fission/fission-server/fission-server)
    Finished dev [unoptimized + debuginfo] target(s) in 2.80s
```