### PR TITLE
feat: add database initialization to nix flake and some direnv helpers

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,2 @@
 use flake
+export DATABASE_URL=postgres://localhost:5432/fission-server

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ private
 *.tmp
 .history
 .DS_Store
+.pg
+postgres.log


### PR DESCRIPTION
Getting postgresql running with diesel in dev mode in diverse environments is a bit tricky. This is an attempt to sidestep some of that, by creating a default database locally (in the `fission-server/.pg/` directory) and providing documentation on how to run a local database with permissive local auth (vs e.g. homebrew's relatively restrictive auth).

This doesn't automatically start the service because nix-shell doesn't appear to have a good way to manage processes, nor does it handle gracefully the case where a developer has a postgresql server already running on port 5432. However, for many it'll simplify the development process, and we can work on handling those edge cases better.'

This PR also adds a .envrc that will automatically be picked up by dotenv and preserve the user's shell configuration, rather than overwriting it with the nix shell (which is what happens with `nix develop`).