### PR TITLE
chore: skip formatting generated files

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,2 +1,3 @@
 edition = "2021"
 imports_granularity = "Crate"
+format_generated_files = false


### PR DESCRIPTION
This ensures the auto-generated schema.rs from diesel-cli doesn't fail the formatting lint.