### PR TITLE
Extend /healthcheck to test database connectivity and schema version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ checksum = "f8175979259124331c1d7bf6586ee7e0da434155e4b2d48ec2c8386281d8df39"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-util",
  "headers",
@@ -406,6 +406,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "blake2b_simd"
@@ -937,11 +943,11 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.0.4"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72eb77396836a4505da85bae0712fa324b74acfe1876d7c2f7e694ef3d0ee373"
+checksum = "f7a532c1f99a0f596f6960a60d1e119e91582b24b39e2d83a190e61262c3ef0c"
 dependencies = [
- "bitflags",
+ "bitflags 2.3.3",
  "byteorder",
  "chrono",
  "diesel_derives",
@@ -951,14 +957,14 @@ dependencies = [
 
 [[package]]
 name = "diesel-async"
-version = "0.2.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5897424d8409385a0cc83d64a44527d15bedb5e3797b65f99daf46374eb6df8e"
+checksum = "a40df24b390b2437af8b934b39acd277c246a08004afb91b8ccbe3137ffd4edc"
 dependencies = [
  "async-trait",
  "bb8",
  "diesel",
- "futures",
+ "futures-util",
  "scoped-futures",
  "tokio",
  "tokio-postgres",
@@ -966,14 +972,23 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad74fdcf086be3d4fdd142f67937678fe60ed431c3b2f08599e7687269410c4"
+checksum = "74398b79d81e52e130d991afeed9c86034bb1b7735f46d2f5bf7deb261d80303"
 dependencies = [
- "proc-macro-error",
+ "diesel_table_macro_syntax",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "diesel_table_macro_syntax"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
+dependencies = [
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1514,7 +1529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
  "base64 0.13.1",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "headers-core",
  "http",
@@ -2365,7 +2380,7 @@ version = "0.10.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2815,7 +2830,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
 dependencies = [
  "autocfg",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "concurrent-queue",
  "libc",
@@ -3124,7 +3139,7 @@ version = "10.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -3155,7 +3170,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -3164,7 +3179,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -3351,7 +3366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
 dependencies = [
  "base64 0.13.1",
- "bitflags",
+ "bitflags 1.3.2",
  "serde",
 ]
 
@@ -3462,7 +3477,7 @@ version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -3585,7 +3600,7 @@ version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -4353,7 +4368,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4372,7 +4387,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d1d42a9b3f3ec46ba828e8d376aec14592ea199f70a06a548587ecd1c4ab658"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-core",
  "futures-util",

--- a/fission-server/Cargo.toml
+++ b/fission-server/Cargo.toml
@@ -44,7 +44,7 @@ config = "0.13"
 console-subscriber = { version = "0.1", default-features = false, features = [ "parking_lot" ], optional = true }
 const_format = "0.2"
 diesel = { version = "2.0.4", features = ["postgres", "chrono"] }
-diesel-async = { version = "0.2.2", features = ["bb8", "postgres"] }
+diesel-async = { version = "0.3", features = ["bb8", "postgres"] }
 fission-core = { path = "../fission-core", version = "0.1" }
 futures = "0.3"
 headers = "0.3"

--- a/fission-server/config/settings.toml
+++ b/fission-server/config/settings.toml
@@ -1,5 +1,6 @@
 [database]
 url = "postgres://postgres:postgres@localhost:5432/fission-server"
+connect_timeout = 3
 
 [monitoring]
 process_collector_interval = 10

--- a/fission-server/config/settings.toml
+++ b/fission-server/config/settings.toml
@@ -24,3 +24,8 @@ subject = "Your Fission Verification Code"
 from_address = "noreply@mail.fission.codes"
 from_name = "Fission"
 template = "test-email-verification"
+
+[healthcheck]
+enabled = true
+interval_ms = 5000
+max_retries = 3

--- a/fission-server/docs/specs/latest.json
+++ b/fission-server/docs/specs/latest.json
@@ -4,8 +4,8 @@
     "title": "fission-server",
     "description": "",
     "contact": {
-      "name": "Zeeshan Lakhani",
-      "email": "zeeshan.lakhani@gmail.com"
+      "name": "Steven Vandevelde",
+      "email": "icid.asset@gmail.com"
     },
     "license": {
       "name": "Apache-2.0"
@@ -13,6 +13,179 @@
     "version": "0.1.0"
   },
   "paths": {
+    "/api/account": {
+      "post": {
+        "tags": [
+          "account"
+        ],
+        "summary": "POST handler for creating a new account",
+        "description": "POST handler for creating a new account\nPOST handler for creating a new account",
+        "operationId": "create_account",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewAccount"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successfully created account",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NewAccount"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ucan_bearer": []
+          }
+        ]
+      }
+    },
+    "/api/account/{name}": {
+      "get": {
+        "tags": [
+          "account"
+        ],
+        "summary": "GET handler to retrieve account details",
+        "description": "GET handler to retrieve account details",
+        "operationId": "get_account",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Found account",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NewAccount"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ucan_bearer": []
+          }
+        ]
+      }
+    },
+    "/api/auth/email/verify": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "POST handler for requesting a new token by email",
+        "description": "POST handler for requesting a new token by email\nPOST handler for requesting a new token by email",
+        "operationId": "request_token",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/email_verification.Request"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully sent request token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "429": {
+            "description": "Too many requests"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ucan_bearer": []
+          }
+        ]
+      }
+    },
     "/healthcheck": {
       "get": {
         "tags": [
@@ -23,7 +196,14 @@
         "operationId": "healthcheck",
         "responses": {
           "200": {
-            "description": "fission-server healthy"
+            "description": "fission-server healthy",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppError"
+                }
+              }
+            }
           },
           "500": {
             "description": "fission-server not healthy",
@@ -35,8 +215,7 @@
               }
             }
           }
-        },
-        "deprecated": false
+        }
       }
     },
     "/ping": {
@@ -61,8 +240,7 @@
               }
             }
           }
-        },
-        "deprecated": false
+        }
       }
     }
   },
@@ -76,17 +254,94 @@
         ],
         "properties": {
           "detail": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "status": {
             "type": "integer",
             "format": "int32",
-            "example": 200
+            "example": 200,
+            "minimum": 0.0
           },
           "title": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "NewAccount": {
+        "type": "object",
+        "description": "Account Request Struct (for creating new accounts)",
+        "required": [
+          "username",
+          "email",
+          "did"
+        ],
+        "properties": {
+          "did": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "username": {
             "type": "string"
           }
         }
+      },
+      "Request": {
+        "type": "object",
+        "description": "[Request] Parameters",
+        "required": [
+          "email",
+          "did"
+        ],
+        "properties": {
+          "code_hash": {
+            "type": "string",
+            "description": "The hash of the code, so that it can only be used by the intended recipient.\nWe only store the hash, not the code itself.",
+            "nullable": true
+          },
+          "did": {
+            "type": "string",
+            "description": "The (pre-generated) did of the client application.\nCurrently only did:key is supported."
+          },
+          "email": {
+            "type": "string",
+            "description": "The email address of the user signing up"
+          }
+        }
+      },
+      "Response": {
+        "type": "object",
+        "description": "Response for Request Token",
+        "required": [
+          "msg"
+        ],
+        "properties": {
+          "msg": {
+            "type": "string"
+          }
+        }
+      },
+      "Volume": {
+        "type": "object",
+        "description": "Volume Struct",
+        "required": [
+          "cid"
+        ],
+        "properties": {
+          "cid": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "ucan_bearer": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
       }
     }
   },

--- a/fission-server/docs/specs/latest.json
+++ b/fission-server/docs/specs/latest.json
@@ -200,17 +200,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AppError"
+                  "$ref": "#/components/schemas/HealthcheckResponse"
                 }
               }
             }
           },
-          "500": {
+          "503": {
             "description": "fission-server not healthy",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AppError"
+                  "$ref": "#/components/schemas/HealthcheckResponse"
                 }
               }
             }
@@ -265,6 +265,22 @@
           },
           "title": {
             "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "HealthcheckResponse": {
+        "type": "object",
+        "description": "A healthcheck response containing diagnostic information for the service",
+        "required": [
+          "database_connected"
+        ],
+        "properties": {
+          "database_connected": {
+            "type": "boolean"
+          },
+          "database_up_to_date": {
+            "type": "boolean",
             "nullable": true
           }
         }

--- a/fission-server/src/db/connection.rs
+++ b/fission-server/src/db/connection.rs
@@ -48,8 +48,10 @@ pub async fn pool() -> Result<Pool> {
 /// Establish a connection
 pub async fn connect(pool: &Pool) -> Result<Conn<'_>> {
     log::error!("trying to connect");
-    let conn = pool.get().await?;
-    Ok(conn)
+
+    pool.get()
+        .await
+        .map_err(|_| anyhow::anyhow!("Failed to connect to database"))
 }
 
 /// Get the current schema version

--- a/fission-server/src/db/mod.rs
+++ b/fission-server/src/db/mod.rs
@@ -5,4 +5,16 @@ pub mod connection;
 #[allow(missing_docs, unused_imports)]
 pub mod schema;
 
-pub use connection::{connect, pool, Conn, Pool};
+pub use connection::{connect, pool, schema_version, Conn, Pool};
+
+diesel::table! {
+    /// Redefine the Diesel schema migrations table for use in healthchecks,
+    /// to verify that all pending migrations have been applied.
+    ///
+    /// Copied from: diesel_migrations::migration_harness
+    #[allow(missing_docs)]
+    __diesel_schema_migrations (version) {
+        version -> VarChar,
+        run_on -> Timestamp,
+    }
+}

--- a/fission-server/src/docs.rs
+++ b/fission-server/src/docs.rs
@@ -14,7 +14,7 @@ use utoipa::OpenApi;
         paths(health::healthcheck, ping::get, auth::request_token,
 account::create_account, account::get_account, //account::update_did,
 ),//volume::get_cid, volume::update_cid),
-        components(schemas(AppError, email_verification::Request, auth::Response, NewAccount, volume::Volume)),
+        components(schemas(AppError, email_verification::Request, auth::Response, NewAccount, volume::Volume, health::HealthcheckResponse)),
         modifiers(&UcanAddon),
         tags(
             (name = "", description = "fission-server service/middleware")

--- a/fission-server/src/router.rs
+++ b/fission-server/src/router.rs
@@ -10,19 +10,28 @@ use axum::{
     Router,
 };
 
+#[derive(Clone, Debug)]
+/// Global application route state.
+pub struct AppState {
+    /// The database pool
+    pub db_pool: Pool,
+    /// The version of the latest database migration at time of application start
+    pub db_version: String,
+}
+
 /// Setup main router for application.
-pub fn setup_app_router(db_pool: Pool) -> Router {
+pub fn setup_app_router(app_state: AppState) -> Router {
     let mut router = Router::new()
         .route("/ping", get(ping::get))
         .fallback(notfound_404)
-        .with_state(db_pool.clone());
+        .with_state(app_state.clone());
 
     let api_router = Router::new()
         .route("/auth/email/verify", post(auth::request_token))
         .route("/account", post(account::create_account))
         .route("/account/:name", get(account::get_account))
         // .route("/account/:name/did", put(account::update_did))
-        .with_state(db_pool.clone())
+        .with_state(app_state.clone())
         .fallback(notfound_404);
 
     router = router.nest("/api", api_router);
@@ -33,7 +42,7 @@ pub fn setup_app_router(db_pool: Pool) -> Router {
     // Healthcheck layer
     let mut healthcheck_router = Router::new()
         .route("/healthcheck", get(health::healthcheck))
-        .with_state(db_pool);
+        .with_state(app_state);
 
     healthcheck_router = healthcheck_router.layer(axum::middleware::from_fn(
         log_request_response::<DebugOnlyLogger>,

--- a/fission-server/src/router.rs
+++ b/fission-server/src/router.rs
@@ -22,7 +22,7 @@ pub fn setup_app_router(db_pool: Pool) -> Router {
         .route("/account", post(account::create_account))
         .route("/account/:name", get(account::get_account))
         // .route("/account/:name/did", put(account::update_did))
-        .with_state(db_pool)
+        .with_state(db_pool.clone())
         .fallback(notfound_404);
 
     router = router.nest("/api", api_router);
@@ -31,7 +31,9 @@ pub fn setup_app_router(db_pool: Pool) -> Router {
     router = router.layer(axum::middleware::from_fn(log_request_response::<Logger>));
 
     // Healthcheck layer
-    let mut healthcheck_router = Router::new().route("/healthcheck", get(health::healthcheck));
+    let mut healthcheck_router = Router::new()
+        .route("/healthcheck", get(health::healthcheck))
+        .with_state(db_pool);
 
     healthcheck_router = healthcheck_router.layer(axum::middleware::from_fn(
         log_request_response::<DebugOnlyLogger>,

--- a/fission-server/src/routes/auth.rs
+++ b/fission-server/src/routes/auth.rs
@@ -2,9 +2,10 @@
 
 use crate::{
     authority::Authority,
-    db::{self, Pool},
+    db::{self},
     error::{AppError, AppResult},
     models::email_verification::{self, EmailVerification},
+    router::AppState,
     settings::Settings,
 };
 use axum::{
@@ -49,7 +50,7 @@ impl Response {
 
 /// POST handler for requesting a new token by email
 pub async fn request_token(
-    State(pool): State<Pool>,
+    State(state): State<AppState>,
     authority: Authority,
     Json(payload): Json<email_verification::Request>,
 ) -> AppResult<(StatusCode, Json<Response>)> {
@@ -107,7 +108,7 @@ pub async fn request_token(
         request.code_hash.clone().unwrap()
     );
 
-    let conn = db::connect(&pool).await;
+    let conn = db::connect(&state.db_pool).await;
 
     let insert_result = EmailVerification::new(conn.unwrap(), request.clone()).await;
     if insert_result.is_err() {

--- a/fission-server/src/routes/health.rs
+++ b/fission-server/src/routes/health.rs
@@ -1,18 +1,55 @@
 //! Healthcheck route.
 
-use crate::error::AppResult;
-use axum::{self, http::StatusCode};
+use crate::{
+    db::{self, Pool},
+    error::AppResult,
+};
+use axum::{self, extract::State, http::StatusCode};
+use diesel_async::pooled_connection::PoolableConnection;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
+use utoipa::ToSchema;
+
+/// A healthcheck response containing diagnostic information for the service
+#[derive(ToSchema, Eq, PartialEq, Debug, Deserialize, Serialize)]
+pub struct HealthcheckResponse {
+    database_connected: bool,
+}
+
+impl HealthcheckResponse {
+    /// Whether the service is healthy
+    pub fn is_healthy(&self) -> bool {
+        self.database_connected
+    }
+
+    /// The status code for the healthcheck response
+    pub fn status_code(&self) -> StatusCode {
+        if self.is_healthy() {
+            StatusCode::OK
+        } else {
+            StatusCode::SERVICE_UNAVAILABLE
+        }
+    }
+}
 
 /// GET handler for checking service health.
 #[utoipa::path(
     get,
     path = "/healthcheck",
     responses(
-        (status = 200, description = "fission-server healthy"),
-        (status = 500, description = "fission-server not healthy", body=AppError)
+        (status = 200, description = "fission-server healthy", body=HealthcheckResponse),
+        (status = 503, description = "fission-server not healthy", body=HealthcheckResponse)
     )
 )]
-pub async fn healthcheck() -> AppResult<(StatusCode, axum::Json<serde_json::Value>)> {
-    Ok((StatusCode::OK, axum::Json(json!({ "msg": "Healthy"}))))
+pub async fn healthcheck(
+    State(pool): State<Pool>,
+) -> AppResult<(StatusCode, axum::Json<serde_json::Value>)> {
+    let database_connected = db::connect(&pool)
+        .await
+        .map(move |mut conn| async move { conn.ping().await.ok() })
+        .is_ok();
+
+    let response = HealthcheckResponse { database_connected };
+
+    Ok((response.status_code(), axum::Json(json! { response})))
 }

--- a/fission-server/src/settings.rs
+++ b/fission-server/src/settings.rs
@@ -97,6 +97,18 @@ pub struct Mailgun {
     pub template: String,
 }
 
+/// Background healthcheck settings
+#[derive(Clone, Debug, Deserialize)]
+pub struct Healthcheck {
+    /// Is background healthcheck enabled?
+    #[serde(rename = "enabled")]
+    pub is_enabled: bool,
+    /// Healthcheck interval in milliseconds.
+    pub interval_ms: u64,
+    /// Healthcheck max retries.
+    pub max_retries: u32,
+}
+
 #[derive(Debug, Deserialize)]
 /// Application settings.
 pub struct Settings {
@@ -105,6 +117,7 @@ pub struct Settings {
     server: Server,
     otel: Otel,
     mailgun: Mailgun,
+    healthcheck: Healthcheck,
 }
 
 impl Settings {
@@ -136,6 +149,11 @@ impl Settings {
     /// Mailgun settings getter.
     pub fn mailgun(&self) -> &Mailgun {
         &self.mailgun
+    }
+
+    /// Healthcheck settings getter.
+    pub fn healthcheck(&self) -> &Healthcheck {
+        &self.healthcheck
     }
 }
 

--- a/fission-server/src/settings.rs
+++ b/fission-server/src/settings.rs
@@ -34,6 +34,8 @@ impl std::fmt::Display for AppEnvironment {
 pub struct Database {
     /// Database URL
     pub url: String,
+    /// Connect Timeout
+    pub connect_timeout: u64,
 }
 
 /// Server settings.

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1682303062,
-        "narHash": "sha256-x+KAADp27lbxeoPXLUMxKcRsUUHDlg+qVjt5PjgBw9A=",
+        "lastModified": 1688392541,
+        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f5364316e314436f6b9c8fd50592b18920ab18f9",
+        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
         "type": "github"
       },
       "original": {
@@ -50,11 +50,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682302828,
-        "narHash": "sha256-5uKDELNLWozRhv02ynzvGf8rx30b0m8DhPTT63IFVHo=",
+        "lastModified": 1689561325,
+        "narHash": "sha256-+UABrHUXtWJSc9mM7oEKPIYQEhTzUVVNy2IPG9Lfrj0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "55de807250dd207007a0697e6e06d9fcba578d81",
+        "rev": "d8a38aea13c67dc2ce10cff93eb274dcf455753f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Resolves https://github.com/fission-codes/fission-server/issues/119

This also adds a background task that hits the endpoint every 5 seconds, killing the server if the healthcheck fails.