### PR TITLE
feat: implement websocket relay for account linking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,7 @@ checksum = "a6a1de45611fdb535bfde7b7de4fd54f4fd2b17b1737c0a59b69bf9b92074b8c"
 dependencies = [
  "async-trait",
  "axum-core",
+ "base64 0.21.2",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
@@ -295,8 +296,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1 0.10.5",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1414,6 +1417,7 @@ dependencies = [
  "config",
  "console-subscriber",
  "const_format",
+ "dashmap",
  "did-key",
  "diesel",
  "diesel-async",
@@ -1421,6 +1425,7 @@ dependencies = [
  "dyn-clone",
  "fission-core",
  "futures",
+ "futures-util",
  "headers",
  "hex",
  "http",
@@ -4875,6 +4880,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec509ac96e9a0c43427c74f003127d953a265737636129424288d27cb5c4b12c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5325,6 +5342,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
+name = "tungstenite"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15fba1a6d6bb030745759a9a2a588bfe8490fc8b4751a277db3a0be1c9ebbf67"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1 0.10.5",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "typed-builder"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5466,6 +5502,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utoipa"

--- a/fission-server/Cargo.toml
+++ b/fission-server/Cargo.toml
@@ -34,7 +34,7 @@ bench = false
 ansi_term = { version = "0.12", optional = true, default-features = false }
 anyhow = { workspace = true }
 async-trait = "0.1.72"
-axum = { workspace = true, features = ["headers"] }
+axum = { workspace = true, features = ["headers", "ws"] }
 axum-macros = "0.3.7"
 axum-server = "0.5.1"
 axum-tracing-opentelemetry = { version = "0.10", features = ["otlp"] }
@@ -46,6 +46,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "serd
 config = "0.13"
 console-subscriber = { version = "0.1", default-features = false, features = [ "parking_lot" ], optional = true }
 const_format = "0.2"
+dashmap = "5.5.0"
 did-key = "0.2.1"
 diesel = { version = "2.0.4", features = ["postgres", "chrono"] }
 diesel-async = { version = "0.3", features = ["bb8", "postgres"] }
@@ -53,6 +54,7 @@ diesel_migrations = "2.1"
 dyn-clone = "1.0.12"
 fission-core = { path = "../fission-core", version = "0.1" }
 futures = "0.3"
+futures-util = "0.3.28"
 headers = "0.3"
 hex = "0.4.3"
 http = "0.2"

--- a/fission-server/src/router.rs
+++ b/fission-server/src/router.rs
@@ -3,7 +3,7 @@
 use crate::{
     app_state::AppState,
     middleware::logging::{log_request_response, DebugOnlyLogger, Logger},
-    routes::{account, auth, doh, fallback::notfound_404, health, ping, volume},
+    routes::{account, auth, doh, fallback::notfound_404, health, ping, volume, ws},
 };
 
 use axum::{
@@ -35,6 +35,7 @@ pub fn setup_app_router(app_state: AppState) -> Router {
     let api_router = Router::new()
         .route("/auth/email/verify", post(auth::request_token))
         .route("/account", post(account::create_account))
+        .route("/account/link/:did", get(ws::handler))
         .route("/account/:name", get(account::get_account))
         .route("/account/:name/did", put(account::update_did))
         .route("/account/:name/volume/cid", get(volume::get_cid))

--- a/fission-server/src/routes/mod.rs
+++ b/fission-server/src/routes/mod.rs
@@ -7,3 +7,4 @@ pub mod fallback;
 pub mod health;
 pub mod ping;
 pub mod volume;
+pub mod ws;

--- a/fission-server/src/routes/ws.rs
+++ b/fission-server/src/routes/ws.rs
@@ -1,0 +1,59 @@
+//! Websocket relay
+
+use std::net::SocketAddr;
+
+use axum::{
+    extract::{ws::WebSocket, ConnectInfo, Path, State, WebSocketUpgrade},
+    response::Response,
+};
+use futures::{channel::mpsc, future, pin_mut, StreamExt, TryStreamExt};
+
+use crate::app_state::{AppState, WsPeerMap};
+
+/// Websocket handler
+pub async fn handler(
+    ws: WebSocketUpgrade,
+    Path(did): Path<String>,
+    State(state): State<AppState>,
+    ConnectInfo(src_addr): ConnectInfo<SocketAddr>,
+) -> Response {
+    ws.on_upgrade(move |socket| handle_socket(did, socket, state.ws_peer_map, src_addr))
+}
+
+async fn handle_socket(did: String, socket: WebSocket, peers: WsPeerMap, src_addr: SocketAddr) {
+    let (tx, rx) = mpsc::channel(64);
+    let (outgoing, incoming) = socket.split();
+
+    peers.entry(did.clone()).or_default().insert(src_addr, tx);
+
+    let broadcast = incoming.try_for_each({
+        let did = did.clone();
+        let peers = peers.clone();
+        move |msg| {
+            let did_peers = peers.get(&did).expect("did should be present in peers");
+            let recipients = did_peers
+                .iter()
+                .filter(|pair| pair.key() != &src_addr)
+                .map(|pair| pair.value().clone());
+
+            for mut recipient in recipients {
+                // If the recipient is no longer available, continue to the next
+                if recipient.try_send(msg.clone()).is_err() {
+                    continue;
+                };
+            }
+
+            future::ok(())
+        }
+    });
+
+    let receive = rx.map(Ok).forward(outgoing);
+
+    pin_mut!(broadcast, receive);
+    future::select(broadcast, receive).await;
+
+    peers
+        .get(&did)
+        .expect("did should be present in peers")
+        .remove(&src_addr);
+}


### PR DESCRIPTION
I haven't yet found a good way to test axum handlers that upgrade to a websocket connection yet, and we're probably need to do e2e testing against a server that actually runs and binds to connections.

This has been manually tested using ts-odd and AWAKE by hacking it up to change the endpoints it hits for device linking.