### PR TITLE
feat: allow ipfs.peers config to be set via env var

### DIFF
--- a/fission-server/src/settings.rs
+++ b/fission-server/src/settings.rs
@@ -176,11 +176,17 @@ impl Settings {
         let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config/settings.toml");
         // inject environment variables naming them properly on the settings
         // e.g. [database] url="foo"
-        // would be injected with environment variable APP_DATABASE_URL="foo"
-        // use one underscore as defined by the separator below
+        // would be injected with environment variable APP__DATABASE__URL="foo"
+        // use two underscores as defined by the separator below
         let s = Config::builder()
             .add_source(File::with_name(&path.as_path().display().to_string()))
-            .add_source(Environment::with_prefix("APP").separator("__"))
+            .add_source(
+                Environment::with_prefix("APP")
+                    .separator("__")
+                    .try_parsing(true)
+                    .list_separator(",")
+                    .with_list_parse_key("ipfs.peers"),
+            )
             .build()?;
         s.try_deserialize()
     }


### PR DESCRIPTION
Small change to allow settings the IPFS peers via an environment variable.