### PR TITLE
refactor: Abstract IPFS persistance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq 0.3.0",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1412,6 +1413,7 @@ dependencies = [
  "base64 0.21.2",
  "base64-url",
  "bb8",
+ "blake3",
  "bytes",
  "chrono",
  "cid",
@@ -1461,6 +1463,8 @@ dependencies = [
  "stringreader",
  "sysinfo",
  "task-local-extensions",
+ "test-log",
+ "testresult",
  "thiserror",
  "time",
  "tokio",
@@ -4704,6 +4708,23 @@ dependencies = [
  "rustix 0.38.4",
  "windows-sys",
 ]
+
+[[package]]
+name = "test-log"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9601d162c1d77e62c1ea0bc8116cd1caf143ce3af947536c3c9052a1677fe0c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "testresult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e045f5cf9ad69772c1c9652f5567a75df88bbb5a1310a64e53cab140c5c459"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "gimli",
 ]
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.2"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
 dependencies = [
  "memchr",
 ]
@@ -74,9 +74,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.72"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 dependencies = [
  "backtrace",
 ]
@@ -180,7 +180,7 @@ checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -228,7 +228,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -239,13 +239,13 @@ checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
 
 [[package]]
 name = "async-trait"
-version = "0.1.72"
+version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
+checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -271,13 +271,13 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a1de45611fdb535bfde7b7de4fd54f4fd2b17b1737c0a59b69bf9b92074b8c"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
  "axum-core",
- "base64 0.21.2",
+ "base64 0.21.3",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
@@ -331,7 +331,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -369,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
 dependencies = [
  "addr2line",
  "cc",
@@ -408,9 +408,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.2"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
 
 [[package]]
 name = "base64-url"
@@ -418,7 +418,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c5b0a88aa36e9f095ee2e2b13fb8c5e4313e022783aedacc123328c0084916d"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.3",
 ]
 
 [[package]]
@@ -448,9 +448,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "bitvec"
@@ -576,9 +576,12 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -588,15 +591,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "95ed24df0632f708f5f6d8082675bef2596f7084dee3dd55f632290bf35bfe0f"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
  "serde",
- "winapi",
+ "windows-targets",
 ]
 
 [[package]]
@@ -696,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
+checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
 
 [[package]]
 name = "const_format"
@@ -777,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "critical-section"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
+checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
 name = "crossbeam-channel"
@@ -918,7 +921,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.27",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -929,14 +932,14 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.29",
 ]
 
 [[package]]
 name = "dashmap"
-version = "5.5.0"
+version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6943ae99c34386c84a470c499d3414f66502a41340aa895406e0d2e4a207b91d"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
  "hashbrown 0.14.0",
@@ -1003,13 +1006,22 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7ed52955ce76b1554f509074bb357d3fb8ac9b51288a65a3fd480d1dfba946"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
 dependencies = [
  "const-oid",
  "pem-rfc7468 0.7.0",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1047,11 +1059,11 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7a532c1f99a0f596f6960a60d1e119e91582b24b39e2d83a190e61262c3ef0c"
+checksum = "d98235fdc2f355d330a8244184ab6b4b33c28679c0b4158f63138e51d6cf7e88"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "byteorder",
  "chrono",
  "diesel_derives",
@@ -1076,14 +1088,14 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74398b79d81e52e130d991afeed9c86034bb1b7735f46d2f5bf7deb261d80303"
+checksum = "e054665eaf6d97d1e7125512bb2d35d07c73ac86cc6920174cb42d1ab697a554"
 dependencies = [
  "diesel_table_macro_syntax",
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1103,7 +1115,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
 dependencies = [
- "syn 2.0.27",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1167,9 +1179,9 @@ checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "304e6508efa593091e97a9abbc10f90aa7ca635b6d2784feff3c89d41dd12272"
+checksum = "bbfc4744c1b8f2a09adc0e55242f60b1af195d88596bd8700be74418c056c555"
 
 [[package]]
 name = "ecdsa"
@@ -1189,7 +1201,7 @@ version = "0.16.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
 dependencies = [
- "der 0.7.7",
+ "der 0.7.8",
  "digest 0.10.7",
  "elliptic-curve 0.13.5",
  "rfc6979 0.4.0",
@@ -1284,9 +1296,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.32"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
 ]
@@ -1317,9 +1329,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -1410,7 +1422,7 @@ dependencies = [
  "axum-macros",
  "axum-server",
  "axum-tracing-opentelemetry",
- "base64 0.21.2",
+ "base64 0.21.3",
  "base64-url",
  "bb8",
  "blake3",
@@ -1472,7 +1484,7 @@ dependencies = [
  "tokio-util",
  "tonic 0.8.3",
  "tower",
- "tower-http 0.4.3",
+ "tower-http 0.4.4",
  "tracing",
  "tracing-appender",
  "tracing-opentelemetry 0.18.0",
@@ -1498,9 +1510,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
+checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1613,7 +1625,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1689,9 +1701,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.3"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
 name = "gloo-timers"
@@ -1729,9 +1741,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
+checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
 dependencies = [
  "bytes",
  "fnv",
@@ -1794,12 +1806,11 @@ dependencies = [
 
 [[package]]
 name = "headers"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
+checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
 dependencies = [
- "base64 0.13.1",
- "bitflags 1.3.2",
+ "base64 0.21.3",
  "bytes",
  "headers-core",
  "http",
@@ -1948,9 +1959,9 @@ checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
 name = "http-serde"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e272971f774ba29341db2f686255ff8a979365a26fb9e4277f6b6d9ec0cdd5e"
+checksum = "6f560b665ad9f1572cfcaf034f7fb84338a7ce945216d64a90fd81f046a3caee"
 dependencies = [
  "http",
  "serde",
@@ -1985,9 +1996,9 @@ checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
@@ -2174,7 +2185,7 @@ dependencies = [
  "socket2 0.5.3",
  "widestring",
  "windows-sys",
- "winreg 0.50.0",
+ "winreg",
 ]
 
 [[package]]
@@ -2409,9 +2420,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "lock_api"
@@ -2425,9 +2436,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 dependencies = [
  "value-bag",
 ]
@@ -2484,9 +2495,9 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matchit"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
+checksum = "ed1202b2a6f884ae56f04cff409ab315c5ce26b5e58d7412e484f01fd52f52ef"
 
 [[package]]
 name = "md-5"
@@ -2499,9 +2510,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "5486aed0026218e61b8a01d5fbd5a0a134649abb71a0e53b7bc088529dced86e"
 
 [[package]]
 name = "memoffset"
@@ -2529,7 +2540,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a4964177ddfdab1e3a2b37aec7cf320e14169abb0ed73999f558136409178d5"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.3",
  "hyper",
  "indexmap 1.9.3",
  "ipnet",
@@ -2549,7 +2560,7 @@ checksum = "ddece26afd34c31585c74a4db0630c376df271c285d682d1e55012197830b6df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -2839,9 +2850,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
 dependencies = [
  "memchr",
 ]
@@ -2860,11 +2871,11 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.55"
+version = "0.10.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
+checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2881,7 +2892,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -2892,18 +2903,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.26.0+1.1.1u"
+version = "111.27.0+1.1.1v"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc62c9f12b22b8f5208c23a7200a442b2e5999f8bdf80233852122b5a4f6f37"
+checksum = "06e8f197c82d7511c5b014030c9b1efeda40d7d5f99d23b4ceed3524a5e63f02"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.90"
+version = "0.9.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
+checksum = "db7e971c2c2bba161b2d2fdf37080177eff520b3bc044787c7f1f5f9e78d869b"
 dependencies = [
  "cc",
  "libc",
@@ -3035,9 +3046,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "3.7.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc2dbde8f8a79f2102cc474ceb0ad68e3b80b85289ea62389b60e66777e4213"
+checksum = "2a54938017eacd63036332b4ae5c8a49fc8c0c1d6d629893057e4f13609edd06"
 dependencies = [
  "num-traits",
 ]
@@ -3176,19 +3187,20 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.7.1"
+version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d2d1d55045829d65aad9d389139882ad623b33b904e7c9f1b10c5b8927298e5"
+checksum = "d7a4d085fd991ac8d5b05a147b437791b4260b76326baf0fc60cf7c9c27ecd33"
 dependencies = [
+ "memchr",
  "thiserror",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.7.1"
+version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f94bca7e7a599d89dea5dfa309e217e7906c3c007fb9c3299c40b10d6a315d3"
+checksum = "a2bee7be22ce7918f641a33f08e3f43388c7656772244e2bbb2477f44cc9021a"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3196,22 +3208,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.1"
+version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d490fe7e8556575ff6911e45567ab95e71617f43781e5c05490dc8d75c965c"
+checksum = "d1511785c5e98d79a05e8a6bc34b4ac2168a0e3e92161862030ad84daa223141"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.29",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.1"
+version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2674c66ebb4b4d9036012091b537aae5878970d6999f81a265034d85b136b341"
+checksum = "b42f0394d3123e33353ca5e1e89092e533d2cc490389f2bd6131c43c634ebc5f"
 dependencies = [
  "once_cell",
  "pest",
@@ -3220,12 +3232,12 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
+checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
 ]
 
 [[package]]
@@ -3248,29 +3260,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
+checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
+checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.29",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.10"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -3296,7 +3308,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der 0.7.7",
+ "der 0.7.8",
  "pkcs8 0.10.2",
  "spki 0.7.2",
 ]
@@ -3317,7 +3329,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.7",
+ "der 0.7.8",
  "spki 0.7.2",
 ]
 
@@ -3345,17 +3357,17 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc55135a600d700580e406b4de0d59cb9ad25e344a3a091a97ded2622ec4ec6"
+checksum = "31114a898e107c51bb1609ffaf55a0e011cf6a4d7f1170d0015a165082c0338b"
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b7fa9f396f51dffd61546fd8573ee20592287996568e6175ceb0f8699ad75d"
+checksum = "49b6c5ef183cd3ab4ba005f1ca64c21e8bd97ce4699cfea9e8d9a2c4958ca520"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.3",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -3369,9 +3381,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f028f05971fe20f512bcc679e2c10227e57809a3af86a7606304435bc8896cd6"
+checksum = "8d2234cdee9408b523530a9b6d2d6b373d1db34f6a8e51dc03ded1828d7fb67c"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -3543,9 +3555,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -3699,14 +3711,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.1"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.3",
- "regex-syntax 0.7.4",
+ "regex-automata 0.3.7",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
@@ -3720,13 +3732,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.3"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
+checksum = "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.4",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
@@ -3737,17 +3749,17 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "reqwest"
-version = "0.11.18"
+version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
+checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.3",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3776,14 +3788,14 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg 0.10.1",
+ "winreg",
 ]
 
 [[package]]
 name = "reqwest-middleware"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4531c89d50effe1fac90d095c8b133c20c5c714204feee0bfc3fd158e784209d"
+checksum = "ff44108c7925d082f2861e683a88618b68235ad9cdc60d64d9d1188efc951cdb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3796,9 +3808,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest-retry"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d0fd6ef4c6d23790399fe15efc8d12cd9f3d4133958f9bd7801ee5cbaec6c4"
+checksum = "5c6a11c05102e5bec712c0619b8c7b7eda8b21a558a0bd981ceee15c38df8be4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3819,9 +3831,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest-tracing"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b97ad83c2fc18113346b7158d79732242002427c30f620fa817c1f32901e0a8"
+checksum = "14b1e66540e0cac90acadaf7109bf99c90d95abcc94b4c096bfa16a2d7aa7a71"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3972,7 +3984,7 @@ dependencies = [
  "quote",
  "rust-embed-utils",
  "shellexpand",
- "syn 2.0.27",
+ "syn 2.0.29",
  "walkdir",
 ]
 
@@ -4036,22 +4048,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.4"
+version = "0.38.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+checksum = "c0c3dde1fc030af041adc40e79c0e7fbcf431dd24870053d187d7c66e4b87453"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.3",
+ "linux-raw-sys 0.4.5",
  "windows-sys",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
 dependencies = [
  "log",
  "ring",
@@ -4077,7 +4089,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.3",
 ]
 
 [[package]]
@@ -4157,7 +4169,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct 0.2.0",
- "der 0.7.7",
+ "der 0.7.8",
  "generic-array",
  "pkcs8 0.10.2",
  "subtle",
@@ -4210,9 +4222,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.179"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5bf42b8d227d4abf38a1ddb08602e229108a517cd4e5bb28f9c7eaafdce5c0"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
@@ -4237,20 +4249,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.179"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "741e124f5485c7e60c03b043f79f320bff3527f4bbf12cf3831750dc46a0ec2c"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.29",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.104"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
  "itoa",
  "ryu",
@@ -4301,14 +4313,15 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.1.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e47d95bc83ed33b2ecf84f4187ad1ab9685d18ff28db000c99deac8ce180e3"
+checksum = "1ca3b16a3d82c4088f343b7480a93550b3eabe1a358569c2dfe38bbcead07237"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.3",
  "chrono",
  "hex",
  "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "serde",
  "serde_json",
  "serde_with_macros",
@@ -4317,14 +4330,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.1.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3cee93715c2e266b9338b7544da68a9f24e227722ba482bd1c024367c77c65"
+checksum = "2e6be15c453eb305019bfa438b1593c731f36a289a7853f7707ee29e870b3b3c"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4436,9 +4449,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "sketches-ddsketch"
@@ -4448,9 +4461,9 @@ checksum = "68a406c1882ed7f29cd5e248c9848a80e7cb6ae0fea82346d2746f2f941c07e1"
 
 [[package]]
 name = "slab"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
@@ -4513,7 +4526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
 dependencies = [
  "base64ct",
- "der 0.7.7",
+ "der 0.7.8",
 ]
 
 [[package]]
@@ -4639,9 +4652,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.27"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4668,9 +4681,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.29.6"
+version = "0.29.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7cb97a5a85a136d84e75d5c3cf89655090602efb1be0d8d5337b7e386af2908"
+checksum = "a8d0e9cc2273cc8d31377bdd638d72e3ac3e5607b18621062b169d02787f1bab"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -4698,14 +4711,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.7.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5486094ee78b2e5038a6382ed7645bc084dc2ec433426ca4c3cb61e2007b8998"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
  "fastrand 2.0.0",
  "redox_syscall 0.3.5",
- "rustix 0.38.4",
+ "rustix 0.38.11",
  "windows-sys",
 ]
 
@@ -4728,22 +4741,22 @@ checksum = "52e045f5cf9ad69772c1c9652f5567a75df88bbb5a1310a64e53cab140c5c459"
 
 [[package]]
 name = "thiserror"
-version = "1.0.44"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
+checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.44"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
+checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4758,10 +4771,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.23"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
+checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
 dependencies = [
+ "deranged",
  "itoa",
  "serde",
  "time-core",
@@ -4776,9 +4790,9 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.10"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
+checksum = "1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572"
 dependencies = [
  "time-core",
 ]
@@ -4800,11 +4814,10 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.29.1"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
+checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
 dependencies = [
- "autocfg",
  "backtrace",
  "bytes",
  "libc",
@@ -4813,7 +4826,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.4.9",
+ "socket2 0.5.3",
  "tokio-macros",
  "tracing",
  "windows-sys",
@@ -4837,7 +4850,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4852,9 +4865,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e89f6234aa8fd43779746012fcf53603cdb91fdd8399aa0de868c2d56b6dde1"
+checksum = "d340244b32d920260ae7448cb72b6e238bddc3d4f7603394e7dd46ed8e48f5b8"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -4869,9 +4882,11 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
+ "rand 0.8.5",
  "socket2 0.5.3",
  "tokio",
  "tokio-util",
+ "whoami",
 ]
 
 [[package]]
@@ -4898,9 +4913,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-test"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53474327ae5e166530d17f2d956afcb4f8a004de581b3cae10f12006bc8163e3"
+checksum = "e89b3cbabd3ae862100094ae433e1def582cf86451b4e9bf83aa7ac1d8a7d719"
 dependencies = [
  "async-stream",
  "bytes",
@@ -4911,9 +4926,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec509ac96e9a0c43427c74f003127d953a265737636129424288d27cb5c4b12c"
+checksum = "2b2dbec703c26b00d74844519606ef15d09a7d6857860f84ad223dec002ddea2"
 dependencies = [
  "futures-util",
  "log",
@@ -5021,7 +5036,7 @@ checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
  "async-trait",
  "axum",
- "base64 0.21.2",
+ "base64 0.21.3",
  "bytes",
  "futures-core",
  "futures-util",
@@ -5095,11 +5110,11 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ae70283aba8d2a8b411c695c437fe25b8b5e44e23e780662002fc72fb47a82"
+checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -5159,7 +5174,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -5396,9 +5411,9 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "tungstenite"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15fba1a6d6bb030745759a9a2a588bfe8490fc8b4751a277db3a0be1c9ebbf67"
+checksum = "e862a1c4128df0112ab625f55cd5c934bcb4312ba80b39ae4b4835a3fd58e649"
 dependencies = [
  "byteorder",
  "bytes",
@@ -5433,13 +5448,13 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 [[package]]
 name = "ucan"
 version = "0.2.0"
-source = "git+https://github.com/blaine/rs-ucan?branch=temporary-unscoped-fix#50ce3e44efc5dc5ad1471552a06d4e9341422a9a"
+source = "git+https://github.com/blaine/rs-ucan?branch=temporary-unscoped-fix#24f00ed8055a15ccfe1ffd7f8c5c81ae70d290e5"
 dependencies = [
  "anyhow",
  "async-recursion",
  "async-std",
  "async-trait",
- "base64 0.21.2",
+ "base64 0.21.3",
  "bs58",
  "cid",
  "futures",
@@ -5460,7 +5475,7 @@ dependencies = [
 [[package]]
 name = "ucan-key-support"
 version = "0.1.3"
-source = "git+https://github.com/blaine/rs-ucan?branch=temporary-unscoped-fix#50ce3e44efc5dc5ad1471552a06d4e9341422a9a"
+source = "git+https://github.com/blaine/rs-ucan?branch=temporary-unscoped-fix#24f00ed8055a15ccfe1ffd7f8c5c81ae70d290e5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5486,9 +5501,9 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "ulid"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13a3aaa69b04e5b66cc27309710a569ea23593612387d67daaf102e73aa974fd"
+checksum = "0f9d3475df4ff8a8f7804c0fc3394b44fdcfc4fb635717bf05fbb7c41c83a376"
 dependencies = [
  "rand 0.8.5",
  "serde",
@@ -5496,9 +5511,9 @@ dependencies = [
 
 [[package]]
 name = "unicase"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
 dependencies = [
  "version_check",
 ]
@@ -5544,9 +5559,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
 dependencies = [
  "form_urlencoded",
  "idna 0.4.0",
@@ -5562,9 +5577,9 @@ checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utoipa"
-version = "3.4.3"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c624186f22e625eb8faa777cb33d34cd595aa16d1742aa1d8b6cf35d3e4dda9"
+checksum = "d82b1bc5417102a73e8464c686eef947bdfb99fcdfc0a4f228e81afa9526470a"
 dependencies = [
  "indexmap 2.0.0",
  "serde",
@@ -5574,23 +5589,23 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "3.4.4"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ce5f21ca77e010f5283fa791c6ab892c68b3668a1bdc6b7ac6cf978f5d5b30"
+checksum = "05d96dcd6fc96f3df9b3280ef480770af1b7c5d14bc55192baa9b067976d920c"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.27",
+ "syn 2.0.29",
  "uuid",
 ]
 
 [[package]]
 name = "utoipa-swagger-ui"
-version = "3.1.4"
+version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4602d7100d3cfd8a086f30494e68532402ab662fa366c9d201d677e33cee138d"
+checksum = "84614caa239fb25b2bb373a52859ffd94605ceb256eeb1d63436325cf81e3653"
 dependencies = [
  "axum",
  "mime_guess",
@@ -5736,7 +5751,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.29",
  "wasm-bindgen-shared",
 ]
 
@@ -5770,7 +5785,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.29",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5808,9 +5823,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+checksum = "f0e74f82d49d545ad128049b7e88f6576df2da6b02e9ce565c6f533be576957e"
 dependencies = [
  "ring",
  "untrusted",
@@ -5834,6 +5849,16 @@ dependencies = [
  "either",
  "libc",
  "once_cell",
+]
+
+[[package]]
+name = "whoami"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -5893,9 +5918,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -5908,62 +5933,53 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.1"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b5872fa2e10bd067ae946f927e726d7d603eaeb6e02fa6a350e0722d2b8c11"
+checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -5984,7 +6000,7 @@ checksum = "c6f71803d3a1c80377a06221e0530be02035d5b3e854af56c6ece7ac20ac441d"
 dependencies = [
  "assert-json-diff",
  "async-trait",
- "base64 0.21.2",
+ "base64 0.21.3",
  "deadpool",
  "futures",
  "futures-timer",
@@ -6050,7 +6066,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.29",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 test-log = { version = "0.2", default-features = false, features = ["trace"] }
 testresult = "0.3"
-ucan = { git = "https://github.com/blaine/rs-ucan", branch = "temporary-unscoped-fix" }
-ucan-key-support = { git = "https://github.com/blaine/rs-ucan", branch = "temporary-unscoped-fix" }
+ucan = { git = "https://github.com/blaine/rs-ucan", branch = "temporary-unscoped-fix", commit = "24f00ed8055a15ccfe1ffd7f8c5c81ae70d290e5" }
+ucan-key-support = { git = "https://github.com/blaine/rs-ucan", branch = "temporary-unscoped-fix", commit = "24f00ed8055a15ccfe1ffd7f8c5c81ae70d290e5" }
 url = "2.3"
 
 # Speedup build on macOS

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ ed25519-zebra = "3.1"
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+test-log = { version = "0.2", default-features = false, features = ["trace"] }
+testresult = "0.3"
 ucan = { git = "https://github.com/blaine/rs-ucan", branch = "temporary-unscoped-fix" }
 ucan-key-support = { git = "https://github.com/blaine/rs-ucan", branch = "temporary-unscoped-fix" }
 url = "2.3"

--- a/fission-server/Cargo.toml
+++ b/fission-server/Cargo.toml
@@ -112,8 +112,11 @@ validator = { version = "0.16.0", features = ["derive"] }
 
 [dev-dependencies]
 assert-json-diff = "2.0"
+blake3 = "1.4.1"
 rsa = { version = "0.9" }
 stringreader = "0.1.1"
+test-log = { workspace = true }
+testresult = { workspace = true }
 tokio-test = "0.4"
 uuid = "1.4.1"
 wiremock = "0.5"

--- a/fission-server/src/app_state.rs
+++ b/fission-server/src/app_state.rs
@@ -1,10 +1,8 @@
 //! The Axum Application State
 
 use anyhow::{anyhow, Result};
-use async_trait::async_trait;
 use axum::extract::ws;
 use dashmap::DashMap;
-use dyn_clone::DynClone;
 use futures::channel::mpsc::Sender;
 use std::{net::SocketAddr, sync::Arc};
 
@@ -26,18 +24,28 @@ pub struct AppState<S: ServerSetup> {
     /// Connection to what stores the IPFS blocks
     pub ipfs_db: S::IpfsDatabase,
     /// The service that sends account verification codes
-    pub verification_code_sender: Box<dyn VerificationCodeSender>,
+    pub verification_code_sender: S::VerificationCodeSender,
     /// The currently connected websocket peers
     pub ws_peer_map: WsPeerMap,
 }
 
-#[derive(Default)]
 /// Builder for [`AppState`]
 pub struct AppStateBuilder<S: ServerSetup> {
     db_pool: Option<Pool>,
     ipfs_peers: Vec<String>,
     ipfs_db: Option<S::IpfsDatabase>,
-    verification_code_sender: Option<Box<dyn VerificationCodeSender>>,
+    verification_code_sender: Option<S::VerificationCodeSender>,
+}
+
+impl<S: ServerSetup> Default for AppStateBuilder<S> {
+    fn default() -> Self {
+        Self {
+            db_pool: None,
+            ipfs_peers: Default::default(),
+            ipfs_db: None,
+            verification_code_sender: None,
+        }
+    }
 }
 
 impl<S: ServerSetup> AppStateBuilder<S> {
@@ -81,28 +89,12 @@ impl<S: ServerSetup> AppStateBuilder<S> {
     }
 
     /// Set the service that sends account verification codes
-    pub fn with_verification_code_sender<T>(mut self, verification_code_sender: T) -> Self
-    where
-        T: VerificationCodeSender + 'static,
-    {
-        self.verification_code_sender = Some(Box::new(verification_code_sender));
+    pub fn with_verification_code_sender(
+        mut self,
+        verification_code_sender: S::VerificationCodeSender,
+    ) -> Self {
+        self.verification_code_sender = Some(verification_code_sender);
         self
-    }
-}
-
-/// The service that sends account verification codes
-#[async_trait]
-pub trait VerificationCodeSender: DynClone + Send + Sync {
-    /// Send the code associated with the email
-    async fn send_code(&self, email: &str, code: &str) -> Result<()>;
-}
-
-dyn_clone::clone_trait_object!(VerificationCodeSender);
-
-#[async_trait]
-impl VerificationCodeSender for Box<dyn VerificationCodeSender> {
-    async fn send_code(&self, email: &str, code: &str) -> Result<()> {
-        self.as_ref().send_code(email, code).await
     }
 }
 
@@ -110,6 +102,7 @@ impl<S> std::fmt::Debug for AppState<S>
 where
     S: ServerSetup,
     S::IpfsDatabase: std::fmt::Debug,
+    S::VerificationCodeSender: std::fmt::Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AppState")
@@ -117,6 +110,7 @@ where
             .field("ipfs_peers", &self.ipfs_peers)
             .field("ipfs_db", &self.ipfs_db)
             .field("ws_peer_map", &self.ws_peer_map)
+            .field("verification_code_sender", &self.verification_code_sender)
             .finish()
     }
 }
@@ -125,12 +119,14 @@ impl<S> std::fmt::Debug for AppStateBuilder<S>
 where
     S: ServerSetup,
     S::IpfsDatabase: std::fmt::Debug,
+    S::VerificationCodeSender: std::fmt::Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AppStateBuilder")
             .field("db_pool", &self.db_pool)
             .field("ipfs_peers", &self.ipfs_peers)
             .field("ipfs_db", &self.ipfs_db)
+            .field("verification_code_sender", &self.verification_code_sender)
             .finish()
     }
 }

--- a/fission-server/src/lib.rs
+++ b/fission-server/src/lib.rs
@@ -24,6 +24,7 @@ pub mod routes;
 pub mod settings;
 pub mod tracer;
 pub mod tracing_layers;
+pub mod traits;
 
 #[cfg(test)]
 mod test_utils;

--- a/fission-server/src/main.rs
+++ b/fission-server/src/main.rs
@@ -22,6 +22,7 @@ use fission_server::{
         metrics_layer::{MetricsLayer, METRIC_META_PREFIX},
         storage_layer::StorageLayer,
     },
+    traits::IpfsHttpApiDatabase,
 };
 use http::header;
 use metrics_exporter_prometheus::PrometheusHandle;
@@ -155,6 +156,7 @@ async fn serve_app(settings: Settings, db_pool: Pool, token: CancellationToken) 
         .with_db_pool(db_pool)
         .with_ipfs_peers(settings.ipfs().peers.clone())
         .with_verification_code_sender(EmailVerificationCodeSender::new(settings.mailgun().clone()))
+        .with_ipfs_db(IpfsHttpApiDatabase::default())
         .finalize()?;
 
     let router = router::setup_app_router(app_state)

--- a/fission-server/src/main.rs
+++ b/fission-server/src/main.rs
@@ -66,6 +66,7 @@ pub struct ProdSetup;
 
 impl ServerSetup for ProdSetup {
     type IpfsDatabase = IpfsHttpApiDatabase;
+    type VerificationCodeSender = EmailVerificationCodeSender;
 }
 
 #[tokio::main]

--- a/fission-server/src/main.rs
+++ b/fission-server/src/main.rs
@@ -22,7 +22,7 @@ use fission_server::{
         metrics_layer::{MetricsLayer, METRIC_META_PREFIX},
         storage_layer::StorageLayer,
     },
-    traits::IpfsHttpApiDatabase,
+    traits::{IpfsHttpApiDatabase, ServerSetup},
 };
 use http::header;
 use metrics_exporter_prometheus::PrometheusHandle;
@@ -60,6 +60,13 @@ use utoipa_swagger_ui::SwaggerUi;
 
 /// Request identifier field.
 const REQUEST_ID: &str = "request_id";
+
+#[derive(Clone, Debug, Default)]
+pub struct ProdSetup;
+
+impl ServerSetup for ProdSetup {
+    type IpfsDatabase = IpfsHttpApiDatabase;
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -152,7 +159,7 @@ async fn serve_metrics(
 async fn serve_app(settings: Settings, db_pool: Pool, token: CancellationToken) -> Result<()> {
     let req_id = HeaderName::from_static(REQUEST_ID);
 
-    let app_state = AppStateBuilder::default()
+    let app_state = AppStateBuilder::<ProdSetup>::default()
         .with_db_pool(db_pool)
         .with_ipfs_peers(settings.ipfs().peers.clone())
         .with_verification_code_sender(EmailVerificationCodeSender::new(settings.mailgun().clone()))

--- a/fission-server/src/models/email_verification.rs
+++ b/fission-server/src/models/email_verification.rs
@@ -14,9 +14,9 @@ use utoipa::ToSchema;
 use validator::{Validate, ValidationError};
 
 use crate::{
-    app_state::VerificationCodeSender,
     db::{schema::email_verifications, Conn},
     settings,
+    traits::VerificationCodeSender,
 };
 
 #[derive(Debug, Clone)]

--- a/fission-server/src/router.rs
+++ b/fission-server/src/router.rs
@@ -4,7 +4,7 @@ use crate::{
     app_state::AppState,
     middleware::logging::{log_request_response, DebugOnlyLogger, Logger},
     routes::{account, auth, doh, fallback::notfound_404, health, ipfs, ping, volume, ws},
-    traits::IpfsDatabase,
+    traits::ServerSetup,
 };
 
 use axum::{
@@ -14,7 +14,7 @@ use axum::{
 use tower_http::cors::{Any, CorsLayer};
 
 /// Setup main router for application.
-pub fn setup_app_router<D: IpfsDatabase + 'static>(app_state: AppState<D>) -> Router {
+pub fn setup_app_router<S: ServerSetup + 'static>(app_state: AppState<S>) -> Router {
     let cors = CorsLayer::new()
         // allow `GET`, `POST`, and `PUT` when accessing the resource
         .allow_methods([http::Method::GET, http::Method::POST, http::Method::PUT])

--- a/fission-server/src/router.rs
+++ b/fission-server/src/router.rs
@@ -4,6 +4,7 @@ use crate::{
     app_state::AppState,
     middleware::logging::{log_request_response, DebugOnlyLogger, Logger},
     routes::{account, auth, doh, fallback::notfound_404, health, ipfs, ping, volume, ws},
+    traits::IpfsDatabase,
 };
 
 use axum::{
@@ -13,7 +14,7 @@ use axum::{
 use tower_http::cors::{Any, CorsLayer};
 
 /// Setup main router for application.
-pub fn setup_app_router(app_state: AppState) -> Router {
+pub fn setup_app_router<D: IpfsDatabase + 'static>(app_state: AppState<D>) -> Router {
     let cors = CorsLayer::new()
         // allow `GET`, `POST`, and `PUT` when accessing the resource
         .allow_methods([http::Method::GET, http::Method::POST, http::Method::PUT])

--- a/fission-server/src/routes/account.rs
+++ b/fission-server/src/routes/account.rs
@@ -9,7 +9,7 @@ use crate::{
         account::{Account, AccountRequest, RootAccount},
         email_verification::EmailVerification,
     },
-    traits::IpfsDatabase,
+    traits::ServerSetup,
 };
 use axum::{
     self,
@@ -38,8 +38,8 @@ use anyhow::{anyhow, Result};
 )]
 
 /// POST handler for creating a new account
-pub async fn create_account<D: IpfsDatabase>(
-    State(state): State<AppState<D>>,
+pub async fn create_account<S: ServerSetup>(
+    State(state): State<AppState<S>>,
     authority: Authority,
     Json(payload): Json<AccountRequest>,
 ) -> AppResult<(StatusCode, Json<RootAccount>)> {
@@ -71,8 +71,8 @@ pub async fn create_account<D: IpfsDatabase>(
 )]
 
 /// GET handler to retrieve account details
-pub async fn get_account<D: IpfsDatabase>(
-    State(state): State<AppState<D>>,
+pub async fn get_account<S: ServerSetup>(
+    State(state): State<AppState<S>>,
     Path(username): Path<String>,
 ) -> AppResult<(StatusCode, Json<AccountRequest>)> {
     let account =
@@ -101,8 +101,8 @@ pub struct AccountUpdateRequest {
 )]
 
 /// Handler to update the DID associated with an account
-pub async fn update_did<D: IpfsDatabase>(
-    State(state): State<AppState<D>>,
+pub async fn update_did<S: ServerSetup>(
+    State(state): State<AppState<S>>,
     authority: Authority,
     Path(username): Path<String>,
     Json(payload): Json<AccountUpdateRequest>,

--- a/fission-server/src/routes/account.rs
+++ b/fission-server/src/routes/account.rs
@@ -9,6 +9,7 @@ use crate::{
         account::{Account, AccountRequest, RootAccount},
         email_verification::EmailVerification,
     },
+    traits::IpfsDatabase,
 };
 use axum::{
     self,
@@ -37,8 +38,8 @@ use anyhow::{anyhow, Result};
 )]
 
 /// POST handler for creating a new account
-pub async fn create_account(
-    State(state): State<AppState>,
+pub async fn create_account<D: IpfsDatabase>(
+    State(state): State<AppState<D>>,
     authority: Authority,
     Json(payload): Json<AccountRequest>,
 ) -> AppResult<(StatusCode, Json<RootAccount>)> {
@@ -70,8 +71,8 @@ pub async fn create_account(
 )]
 
 /// GET handler to retrieve account details
-pub async fn get_account(
-    State(state): State<AppState>,
+pub async fn get_account<D: IpfsDatabase>(
+    State(state): State<AppState<D>>,
     Path(username): Path<String>,
 ) -> AppResult<(StatusCode, Json<AccountRequest>)> {
     let account =
@@ -100,8 +101,8 @@ pub struct AccountUpdateRequest {
 )]
 
 /// Handler to update the DID associated with an account
-pub async fn update_did(
-    State(state): State<AppState>,
+pub async fn update_did<D: IpfsDatabase>(
+    State(state): State<AppState<D>>,
     authority: Authority,
     Path(username): Path<String>,
     Json(payload): Json<AccountUpdateRequest>,

--- a/fission-server/src/routes/auth.rs
+++ b/fission-server/src/routes/auth.rs
@@ -7,6 +7,7 @@ use crate::{
     error::{AppError, AppResult},
     models::email_verification::{self, EmailVerification},
     settings::Settings,
+    traits::IpfsDatabase,
 };
 use axum::{
     self,
@@ -49,8 +50,8 @@ impl VerificationCodeResponse {
 )]
 
 /// POST handler for requesting a new token by email
-pub async fn request_token(
-    State(state): State<AppState>,
+pub async fn request_token<D: IpfsDatabase>(
+    State(state): State<AppState<D>>,
     authority: Authority,
     Json(payload): Json<email_verification::Request>,
 ) -> AppResult<(StatusCode, Json<VerificationCodeResponse>)> {

--- a/fission-server/src/routes/auth.rs
+++ b/fission-server/src/routes/auth.rs
@@ -117,23 +117,16 @@ mod tests {
     use anyhow::Result;
     use http::{Method, StatusCode};
     use serde_json::json;
-    use tokio::sync::broadcast;
 
     use crate::{
         error::{AppError, ErrorResponse},
         routes::auth::VerificationCodeResponse,
-        test_utils::{
-            test_context::TestContext, BroadcastVerificationCodeSender, RouteBuilder, UcanBuilder,
-        },
+        test_utils::{test_context::TestContext, RouteBuilder, UcanBuilder},
     };
 
     #[tokio::test]
     async fn test_request_code_ok() -> Result<()> {
-        let (tx, mut rx) = broadcast::channel(1);
-        let ctx = TestContext::new_with_state(|builder| {
-            builder.with_verification_code_sender(BroadcastVerificationCodeSender(tx))
-        })
-        .await;
+        let ctx = TestContext::new().await;
 
         let email = "oedipa@trystero.com";
         let (ucan, _) = UcanBuilder::default().finalize().await?;
@@ -144,7 +137,12 @@ mod tests {
             .into_json_response::<VerificationCodeResponse>()
             .await?;
 
-        let (email, _) = rx.recv().await?;
+        let (email, _) = ctx
+            .verification_code_sender()
+            .get_emails()
+            .into_iter()
+            .last()
+            .expect("No email sent");
 
         assert_eq!(status, StatusCode::OK);
         assert_eq!(email, "oedipa@trystero.com");

--- a/fission-server/src/routes/auth.rs
+++ b/fission-server/src/routes/auth.rs
@@ -7,7 +7,7 @@ use crate::{
     error::{AppError, AppResult},
     models::email_verification::{self, EmailVerification},
     settings::Settings,
-    traits::IpfsDatabase,
+    traits::ServerSetup,
 };
 use axum::{
     self,
@@ -50,8 +50,8 @@ impl VerificationCodeResponse {
 )]
 
 /// POST handler for requesting a new token by email
-pub async fn request_token<D: IpfsDatabase>(
-    State(state): State<AppState<D>>,
+pub async fn request_token<S: ServerSetup>(
+    State(state): State<AppState<S>>,
     authority: Authority,
     Json(payload): Json<email_verification::Request>,
 ) -> AppResult<(StatusCode, Json<VerificationCodeResponse>)> {

--- a/fission-server/src/routes/doh.rs
+++ b/fission-server/src/routes/doh.rs
@@ -12,12 +12,12 @@ use crate::{
     app_state::AppState,
     dns,
     extract::doh::{DNSMimeType, DNSRequestBody, DNSRequestQuery},
-    traits::IpfsDatabase,
+    traits::ServerSetup,
 };
 
 /// GET handler for resolving DoH queries
-pub async fn get<D: IpfsDatabase>(
-    State(state): State<AppState<D>>,
+pub async fn get<S: ServerSetup>(
+    State(state): State<AppState<S>>,
     DNSRequestQuery(request, accept_type): DNSRequestQuery,
 ) -> Response {
     let response = match dns::handle_request(request, state.db_pool).await {
@@ -47,8 +47,8 @@ pub async fn get<D: IpfsDatabase>(
 }
 
 /// POST handler for resolvng DoH queries
-pub async fn post<D: IpfsDatabase>(
-    State(state): State<AppState<D>>,
+pub async fn post<S: ServerSetup>(
+    State(state): State<AppState<S>>,
     DNSRequestBody(request): DNSRequestBody,
 ) -> Response {
     let response = match dns::handle_request(request, state.db_pool).await {

--- a/fission-server/src/routes/doh.rs
+++ b/fission-server/src/routes/doh.rs
@@ -12,11 +12,12 @@ use crate::{
     app_state::AppState,
     dns,
     extract::doh::{DNSMimeType, DNSRequestBody, DNSRequestQuery},
+    traits::IpfsDatabase,
 };
 
 /// GET handler for resolving DoH queries
-pub async fn get(
-    State(state): State<AppState>,
+pub async fn get<D: IpfsDatabase>(
+    State(state): State<AppState<D>>,
     DNSRequestQuery(request, accept_type): DNSRequestQuery,
 ) -> Response {
     let response = match dns::handle_request(request, state.db_pool).await {
@@ -46,8 +47,8 @@ pub async fn get(
 }
 
 /// POST handler for resolvng DoH queries
-pub async fn post(
-    State(state): State<AppState>,
+pub async fn post<D: IpfsDatabase>(
+    State(state): State<AppState<D>>,
     DNSRequestBody(request): DNSRequestBody,
 ) -> Response {
     let response = match dns::handle_request(request, state.db_pool).await {

--- a/fission-server/src/routes/health.rs
+++ b/fission-server/src/routes/health.rs
@@ -4,6 +4,7 @@ use crate::{
     app_state::AppState,
     db::{self, MIGRATIONS},
     error::AppResult,
+    traits::IpfsDatabase,
 };
 use axum::{self, extract::State, http::StatusCode};
 use diesel::{
@@ -48,8 +49,8 @@ impl HealthcheckResponse {
         (status = 503, description = "fission-server not healthy", body=HealthcheckResponse)
     )
 )]
-pub async fn healthcheck(
-    State(state): State<AppState>,
+pub async fn healthcheck<D: IpfsDatabase>(
+    State(state): State<AppState<D>>,
 ) -> AppResult<(StatusCode, axum::Json<serde_json::Value>)> {
     let (database_connected, database_up_to_date) =
         if let Ok(mut conn) = db::connect(&state.db_pool).await {

--- a/fission-server/src/routes/health.rs
+++ b/fission-server/src/routes/health.rs
@@ -4,7 +4,7 @@ use crate::{
     app_state::AppState,
     db::{self, MIGRATIONS},
     error::AppResult,
-    traits::IpfsDatabase,
+    traits::ServerSetup,
 };
 use axum::{self, extract::State, http::StatusCode};
 use diesel::{
@@ -49,8 +49,8 @@ impl HealthcheckResponse {
         (status = 503, description = "fission-server not healthy", body=HealthcheckResponse)
     )
 )]
-pub async fn healthcheck<D: IpfsDatabase>(
-    State(state): State<AppState<D>>,
+pub async fn healthcheck<S: ServerSetup>(
+    State(state): State<AppState<S>>,
 ) -> AppResult<(StatusCode, axum::Json<serde_json::Value>)> {
     let (database_connected, database_up_to_date) =
         if let Ok(mut conn) = db::connect(&state.db_pool).await {

--- a/fission-server/src/routes/ipfs.rs
+++ b/fission-server/src/routes/ipfs.rs
@@ -8,10 +8,12 @@ use axum::{
 };
 use serde_json::json;
 
-use crate::{app_state::AppState, error::AppResult};
+use crate::{app_state::AppState, error::AppResult, traits::IpfsDatabase};
 
 /// Render a list of IPFS node addresses
-pub async fn peers(State(state): State<AppState>) -> AppResult<(StatusCode, Response)> {
+pub async fn peers<D: IpfsDatabase>(
+    State(state): State<AppState<D>>,
+) -> AppResult<(StatusCode, Response)> {
     let json = json!(state.ipfs_peers);
     Ok((StatusCode::OK, Json(json).into_response()))
 }

--- a/fission-server/src/routes/ipfs.rs
+++ b/fission-server/src/routes/ipfs.rs
@@ -8,11 +8,11 @@ use axum::{
 };
 use serde_json::json;
 
-use crate::{app_state::AppState, error::AppResult, traits::IpfsDatabase};
+use crate::{app_state::AppState, error::AppResult, traits::ServerSetup};
 
 /// Render a list of IPFS node addresses
-pub async fn peers<D: IpfsDatabase>(
-    State(state): State<AppState<D>>,
+pub async fn peers<S: ServerSetup>(
+    State(state): State<AppState<S>>,
 ) -> AppResult<(StatusCode, Response)> {
     let json = json!(state.ipfs_peers);
     Ok((StatusCode::OK, Json(json).into_response()))

--- a/fission-server/src/routes/volume.rs
+++ b/fission-server/src/routes/volume.rs
@@ -6,7 +6,7 @@ use crate::{
     db::{self},
     error::{AppError, AppResult},
     models::{account::Account, volume::NewVolumeRecord},
-    traits::IpfsDatabase,
+    traits::ServerSetup,
 };
 use axum::extract::{Json, Path, State};
 use http::StatusCode;
@@ -25,8 +25,8 @@ use http::StatusCode;
 )]
 
 /// GET handler to retrieve account volume CID
-pub async fn get_cid<D: IpfsDatabase>(
-    State(state): State<AppState<D>>,
+pub async fn get_cid<S: ServerSetup>(
+    State(state): State<AppState<S>>,
     Path(username): Path<String>,
 ) -> AppResult<(StatusCode, Json<NewVolumeRecord>)> {
     let mut conn = db::connect(&state.db_pool).await?;
@@ -57,8 +57,8 @@ pub async fn get_cid<D: IpfsDatabase>(
 )]
 
 /// Handler to create a new volume for an account
-pub async fn create_volume<D: IpfsDatabase>(
-    State(state): State<AppState<D>>,
+pub async fn create_volume<S: ServerSetup>(
+    State(state): State<AppState<S>>,
     authority: Authority,
     Path(username): Path<String>,
     Json(payload): Json<NewVolumeRecord>,
@@ -96,8 +96,8 @@ pub async fn create_volume<D: IpfsDatabase>(
 )]
 
 /// Handler to update the CID associated with an account's volume
-pub async fn update_cid<D: IpfsDatabase>(
-    State(state): State<AppState<D>>,
+pub async fn update_cid<S: ServerSetup>(
+    State(state): State<AppState<S>>,
     authority: Authority,
     Path(username): Path<String>,
     Json(payload): Json<NewVolumeRecord>,

--- a/fission-server/src/routes/volume.rs
+++ b/fission-server/src/routes/volume.rs
@@ -6,6 +6,7 @@ use crate::{
     db::{self},
     error::{AppError, AppResult},
     models::{account::Account, volume::NewVolumeRecord},
+    traits::IpfsDatabase,
 };
 use axum::extract::{Json, Path, State};
 use http::StatusCode;
@@ -24,8 +25,8 @@ use http::StatusCode;
 )]
 
 /// GET handler to retrieve account volume CID
-pub async fn get_cid(
-    State(state): State<AppState>,
+pub async fn get_cid<D: IpfsDatabase>(
+    State(state): State<AppState<D>>,
     Path(username): Path<String>,
 ) -> AppResult<(StatusCode, Json<NewVolumeRecord>)> {
     let mut conn = db::connect(&state.db_pool).await?;
@@ -56,8 +57,8 @@ pub async fn get_cid(
 )]
 
 /// Handler to create a new volume for an account
-pub async fn create_volume(
-    State(state): State<AppState>,
+pub async fn create_volume<D: IpfsDatabase>(
+    State(state): State<AppState<D>>,
     authority: Authority,
     Path(username): Path<String>,
     Json(payload): Json<NewVolumeRecord>,
@@ -69,7 +70,9 @@ pub async fn create_volume(
         .has_capability("ucan:*", "ucan/*", &account.did)
         .await?;
     if allowed {
-        let volume = account.set_volume_cid(&mut conn, &payload.cid).await?;
+        let volume = account
+            .set_volume_cid(&mut conn, &payload.cid, &state.ipfs_db)
+            .await?;
         Ok((StatusCode::CREATED, Json(volume)))
     } else {
         Err(AppError::new(
@@ -93,8 +96,8 @@ pub async fn create_volume(
 )]
 
 /// Handler to update the CID associated with an account's volume
-pub async fn update_cid(
-    State(state): State<AppState>,
+pub async fn update_cid<D: IpfsDatabase>(
+    State(state): State<AppState<D>>,
     authority: Authority,
     Path(username): Path<String>,
     Json(payload): Json<NewVolumeRecord>,
@@ -118,9 +121,13 @@ pub async fn update_cid(
     if let Ok(allowed) = allowed {
         if allowed {
             let volume: NewVolumeRecord = if account.volume_id.is_some() {
-                account.update_volume_cid(&mut conn, &payload.cid).await?
+                account
+                    .update_volume_cid(&mut conn, &payload.cid, &state.ipfs_db)
+                    .await?
             } else {
-                account.set_volume_cid(&mut conn, &payload.cid).await?
+                account
+                    .set_volume_cid(&mut conn, &payload.cid, &state.ipfs_db)
+                    .await?
             };
 
             Ok((StatusCode::OK, Json(volume)))
@@ -142,7 +149,6 @@ pub async fn update_cid(
 mod tests {
     use anyhow::Result;
     use http::{Method, StatusCode};
-    use ipfs_api_backend_hyper::IpfsApi;
     use serde_json::json;
     use stringreader::StringReader;
     use tracing_test::traced_test;
@@ -183,16 +189,12 @@ mod tests {
             .await?;
 
         let hw_string = StringReader::new("Hello World!");
-        let ipfs_result = ipfs_api::IpfsClient::default().add(hw_string).await;
-
-        if ipfs_result.is_err() {
-            return Err(anyhow::anyhow!("Error communicating with IPFS node"));
-        }
+        let hw_cid = ctx.ipfs_db().add(hw_string)?;
 
         let (status, _) = RouteBuilder::new(ctx.app(), Method::POST, "/api/account/tuttle/volume")
             .with_ucan(ucan)
             .with_ucan_proof(root_account.ucan)
-            .with_json_body(json!({ "cid": ipfs_result.unwrap().name }))?
+            .with_json_body(json!({ "cid": hw_cid.to_string() }))?
             .into_raw_response()
             .await?;
 
@@ -242,6 +244,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[traced_test]
     async fn test_update_volume_ok() -> Result<()> {
         let ctx = TestContext::new().await;
 
@@ -262,15 +265,11 @@ mod tests {
         .await?;
 
         let hw_string = StringReader::new("Hello World!");
-        let ipfs_result = ipfs_api::IpfsClient::default().add(hw_string).await;
-
-        if ipfs_result.is_err() {
-            return Err(anyhow::anyhow!("Error communicating with IPFS node"));
-        }
+        let hw_cid = ctx.ipfs_db().add(hw_string)?;
 
         root_account
             .account
-            .set_volume_cid(&mut conn, &ipfs_result.unwrap().name)
+            .set_volume_cid(&mut conn, &hw_cid.to_string(), &ctx.ipfs_db())
             .await?;
 
         let (ucan, _) = UcanBuilder::default()
@@ -378,7 +377,11 @@ mod tests {
 
         root_account
             .account
-            .set_volume_cid(&mut conn, "Qmf1rtki74jvYmGeqaaV51hzeiaa6DyWc98fzDiuPatzyy")
+            .set_volume_cid(
+                &mut conn,
+                "Qmf1rtki74jvYmGeqaaV51hzeiaa6DyWc98fzDiuPatzyy",
+                &ctx.ipfs_db(),
+            )
             .await?;
 
         let (status, _) =

--- a/fission-server/src/routes/volume.rs
+++ b/fission-server/src/routes/volume.rs
@@ -269,7 +269,7 @@ mod tests {
 
         root_account
             .account
-            .set_volume_cid(&mut conn, &hw_cid.to_string(), &ctx.ipfs_db())
+            .set_volume_cid(&mut conn, &hw_cid.to_string(), ctx.ipfs_db())
             .await?;
 
         let (ucan, _) = UcanBuilder::default()
@@ -380,7 +380,7 @@ mod tests {
             .set_volume_cid(
                 &mut conn,
                 "Qmf1rtki74jvYmGeqaaV51hzeiaa6DyWc98fzDiuPatzyy",
-                &ctx.ipfs_db(),
+                ctx.ipfs_db(),
             )
             .await?;
 

--- a/fission-server/src/routes/ws.rs
+++ b/fission-server/src/routes/ws.rs
@@ -10,14 +10,14 @@ use futures::{channel::mpsc, future, pin_mut, StreamExt, TryStreamExt};
 
 use crate::{
     app_state::{AppState, WsPeerMap},
-    traits::IpfsDatabase,
+    traits::ServerSetup,
 };
 
 /// Websocket handler
-pub async fn handler<D: IpfsDatabase>(
+pub async fn handler<S: ServerSetup>(
     ws: WebSocketUpgrade,
     Path(did): Path<String>,
-    State(state): State<AppState<D>>,
+    State(state): State<AppState<S>>,
     ConnectInfo(src_addr): ConnectInfo<SocketAddr>,
 ) -> Response {
     ws.on_upgrade(move |socket| handle_socket(did, socket, state.ws_peer_map, src_addr))

--- a/fission-server/src/routes/ws.rs
+++ b/fission-server/src/routes/ws.rs
@@ -8,13 +8,16 @@ use axum::{
 };
 use futures::{channel::mpsc, future, pin_mut, StreamExt, TryStreamExt};
 
-use crate::app_state::{AppState, WsPeerMap};
+use crate::{
+    app_state::{AppState, WsPeerMap},
+    traits::IpfsDatabase,
+};
 
 /// Websocket handler
-pub async fn handler(
+pub async fn handler<D: IpfsDatabase>(
     ws: WebSocketUpgrade,
     Path(did): Path<String>,
-    State(state): State<AppState>,
+    State(state): State<AppState<D>>,
     ConnectInfo(src_addr): ConnectInfo<SocketAddr>,
 ) -> Response {
     ws.on_upgrade(move |socket| handle_socket(did, socket, state.ws_peer_map, src_addr))

--- a/fission-server/src/test_utils/mod.rs
+++ b/fission-server/src/test_utils/mod.rs
@@ -22,6 +22,7 @@ use ucan_key_support::ed25519::Ed25519KeyMaterial;
 use crate::app_state::VerificationCodeSender;
 
 pub(crate) mod test_context;
+pub(crate) mod test_ipfs_database;
 
 pub(crate) trait Fact: Serialize + DeserializeOwned {}
 

--- a/fission-server/src/test_utils/mod.rs
+++ b/fission-server/src/test_utils/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, Mutex};
+
 use anyhow::Result;
 use async_trait::async_trait;
 use axum::Router;
@@ -11,7 +13,6 @@ use http::{Method, Request, StatusCode, Uri};
 use hyper::Body;
 use mime::{Mime, APPLICATION_JSON};
 use serde::{de::DeserializeOwned, Serialize};
-use tokio::sync::broadcast;
 use tower::ServiceExt;
 use ucan::{
     capability::{Capability, CapabilitySemantics},
@@ -19,7 +20,7 @@ use ucan::{
 };
 use ucan_key_support::ed25519::Ed25519KeyMaterial;
 
-use crate::app_state::VerificationCodeSender;
+use crate::traits::VerificationCodeSender;
 
 pub(crate) mod test_context;
 pub(crate) mod test_ipfs_database;
@@ -222,23 +223,23 @@ impl RouteBuilder {
 }
 
 #[derive(Debug, Clone, Default)]
-pub(crate) struct MockVerificationCodeSender;
+pub(crate) struct TestVerificationCodeSender {
+    emails: Arc<Mutex<Vec<(String, String)>>>,
+}
 
-#[async_trait]
-impl VerificationCodeSender for MockVerificationCodeSender {
-    async fn send_code(&self, _email: &str, _code: &str) -> Result<()> {
-        Ok(())
+impl TestVerificationCodeSender {
+    pub(crate) fn get_emails(&self) -> Vec<(String, String)> {
+        self.emails.lock().unwrap().clone()
     }
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct BroadcastVerificationCodeSender(pub(crate) broadcast::Sender<(String, String)>);
-
 #[async_trait]
-impl VerificationCodeSender for BroadcastVerificationCodeSender {
+impl VerificationCodeSender for TestVerificationCodeSender {
     async fn send_code(&self, email: &str, code: &str) -> Result<()> {
-        self.0.send((email.to_string(), code.to_string()))?;
-
+        self.emails
+            .lock()
+            .unwrap()
+            .push((email.to_string(), code.to_string()));
         Ok(())
     }
 }

--- a/fission-server/src/test_utils/test_context.rs
+++ b/fission-server/src/test_utils/test_context.rs
@@ -11,15 +11,23 @@ use crate::{
     db::{self, Conn, MIGRATIONS},
     router::setup_app_router,
     test_utils::MockVerificationCodeSender,
+    traits::ServerSetup,
 };
 
 use super::test_ipfs_database::TestIpfsDatabase;
 
 pub(crate) struct TestContext {
     app: Router,
-    app_state: AppState<TestIpfsDatabase>,
+    app_state: AppState<TestSetup>,
     base_url: String,
     db_name: String,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct TestSetup;
+
+impl ServerSetup for TestSetup {
+    type IpfsDatabase = TestIpfsDatabase;
 }
 
 impl TestContext {
@@ -29,7 +37,7 @@ impl TestContext {
 
     pub(crate) async fn new_with_state<F>(f: F) -> Self
     where
-        F: FnOnce(AppStateBuilder<TestIpfsDatabase>) -> AppStateBuilder<TestIpfsDatabase>,
+        F: FnOnce(AppStateBuilder<TestSetup>) -> AppStateBuilder<TestSetup>,
     {
         let base_url = "postgres://postgres:postgres@localhost:5432";
         let db_name = format!("fission_server_test_{}", Uuid::new_v4().simple());

--- a/fission-server/src/test_utils/test_context.rs
+++ b/fission-server/src/test_utils/test_context.rs
@@ -10,7 +10,7 @@ use crate::{
     app_state::{AppState, AppStateBuilder},
     db::{self, Conn, MIGRATIONS},
     router::setup_app_router,
-    test_utils::MockVerificationCodeSender,
+    test_utils::TestVerificationCodeSender,
     traits::ServerSetup,
 };
 
@@ -28,6 +28,7 @@ pub(crate) struct TestSetup;
 
 impl ServerSetup for TestSetup {
     type IpfsDatabase = TestIpfsDatabase;
+    type VerificationCodeSender = TestVerificationCodeSender;
 }
 
 impl TestContext {
@@ -65,7 +66,7 @@ impl TestContext {
         let builder = AppStateBuilder::default()
             .with_db_pool(db_pool)
             .with_ipfs_db(TestIpfsDatabase::default())
-            .with_verification_code_sender(MockVerificationCodeSender);
+            .with_verification_code_sender(TestVerificationCodeSender::default());
 
         let app_state = f(builder).finalize().unwrap();
 
@@ -89,8 +90,12 @@ impl TestContext {
         self.app_state.db_pool.get().await.unwrap()
     }
 
-    pub(crate) fn ipfs_db(&self) -> TestIpfsDatabase {
-        self.app_state.ipfs_db.clone()
+    pub(crate) fn ipfs_db(&self) -> &TestIpfsDatabase {
+        &self.app_state.ipfs_db
+    }
+
+    pub(crate) fn verification_code_sender(&self) -> &TestVerificationCodeSender {
+        &self.app_state.verification_code_sender
     }
 }
 

--- a/fission-server/src/test_utils/test_ipfs_database.rs
+++ b/fission-server/src/test_utils/test_ipfs_database.rs
@@ -1,0 +1,56 @@
+use crate::traits::IpfsDatabase;
+use anyhow::Result;
+use async_trait::async_trait;
+use bytes::Bytes;
+use cid::{multihash::MultihashGeneric as Multihash, Cid};
+use std::{
+    cell::RefCell,
+    collections::{HashMap, HashSet},
+    io::Read,
+    sync::{Arc, Mutex},
+};
+
+#[derive(Debug, Default, Clone)]
+pub(crate) struct TestIpfsDatabase {
+    inner: Arc<Mutex<RefCell<State>>>,
+}
+
+#[derive(Debug, Default)]
+struct State {
+    pinned_cids: HashSet<Cid>,
+    blocks: HashMap<Cid, Bytes>,
+}
+
+impl TestIpfsDatabase {
+    pub(crate) fn add(&self, mut data: impl Read) -> Result<Cid> {
+        let mut bytes = Vec::new();
+        data.read_to_end(&mut bytes)?;
+
+        let hash = blake3::hash(&bytes);
+        let cid = Cid::new_v1(0x55, Multihash::wrap(0x1e, hash.as_bytes())?);
+
+        let bytes = Bytes::from(bytes);
+
+        self.inner
+            .lock()
+            .unwrap()
+            .borrow_mut()
+            .blocks
+            .insert(cid, bytes);
+        Ok(cid)
+    }
+}
+
+#[async_trait]
+impl IpfsDatabase for TestIpfsDatabase {
+    async fn pin_add(&self, cid: &str, _recursive: bool) -> Result<()> {
+        let cid: Cid = cid.try_into()?;
+        self.inner
+            .lock()
+            .unwrap()
+            .borrow_mut()
+            .pinned_cids
+            .insert(cid);
+        Ok(())
+    }
+}

--- a/fission-server/src/traits.rs
+++ b/fission-server/src/traits.rs
@@ -1,0 +1,35 @@
+//! All custom traits defined in fission-server
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use ipfs_api::IpfsApi;
+
+/// Provides functionality for storing IPFS data.
+/// Abstracted away, so you can plug in a real kubo node
+/// or an in-memory test database.
+#[async_trait]
+pub trait IpfsDatabase: Clone + Send + Sync {
+    /// Pin a DAG by CID.
+    async fn pin_add(&self, cid: &str, recursive: bool) -> Result<()>;
+}
+
+/// An implementation of `IpfsDatabase` which connects to a locally-running
+/// IPFS kubo node.
+#[derive(Clone, Default)]
+pub struct IpfsHttpApiDatabase(ipfs_api::IpfsClient);
+
+impl std::fmt::Debug for IpfsHttpApiDatabase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("IpfsHttpApiDatabase").finish()
+    }
+}
+
+#[async_trait]
+impl IpfsDatabase for IpfsHttpApiDatabase {
+    async fn pin_add(&self, cid: &str, recursive: bool) -> Result<()> {
+        self.0
+            .pin_add(cid, recursive)
+            .await
+            .map_err(|e| anyhow!("Failed to pin CID: {e}"))?;
+        Ok(())
+    }
+}

--- a/fission-server/src/traits.rs
+++ b/fission-server/src/traits.rs
@@ -10,6 +10,8 @@ use ipfs_api::IpfsApi;
 pub trait ServerSetup: Clone + Send + Sync {
     /// Which implementation for an IPFS database to choose
     type IpfsDatabase: IpfsDatabase;
+    /// Which implementation to use to send verification codes
+    type VerificationCodeSender: VerificationCodeSender;
 }
 
 /// Provides functionality for storing IPFS data.
@@ -19,6 +21,13 @@ pub trait ServerSetup: Clone + Send + Sync {
 pub trait IpfsDatabase: Clone + Send + Sync {
     /// Pin a DAG by CID.
     async fn pin_add(&self, cid: &str, recursive: bool) -> Result<()>;
+}
+
+/// The service that sends account verification codes
+#[async_trait]
+pub trait VerificationCodeSender: Clone + Send + Sync {
+    /// Send the code associated with the email
+    async fn send_code(&self, email: &str, code: &str) -> Result<()>;
 }
 
 /// An implementation of `IpfsDatabase` which connects to a locally-running

--- a/fission-server/src/traits.rs
+++ b/fission-server/src/traits.rs
@@ -3,6 +3,15 @@ use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use ipfs_api::IpfsApi;
 
+/// This trait groups type parameters to the server's `AppState` struct.
+///
+/// It captures the setup of the server, distinguishing between e.g.
+/// unit testing & production setups.
+pub trait ServerSetup: Clone + Send + Sync {
+    /// Which implementation for an IPFS database to choose
+    type IpfsDatabase: IpfsDatabase;
+}
+
 /// Provides functionality for storing IPFS data.
 /// Abstracted away, so you can plug in a real kubo node
 /// or an in-memory test database.


### PR DESCRIPTION
- abstracts out an `IpfsDatabase` trait, so we can run tests without having to run `kubo` next to them
- also collects all "abstract" server state into a single parameter `S: ServerSetup`, which can either be `TestSetup` or `ProdSetup` and use the the correct implementations of `IpfsDatabase` and `VerificationCodeSender` respectively
- adjusted `VerificationCodeSender` to be used via `ServerSetup` instead of as a `dyn trait`

This should make CI work again :tada: 