### PR TITLE
`/api/v0/capabilities` route

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,6 +993,7 @@ dependencies = [
  "diesel_derives",
  "itoa",
  "pq-sys",
+ "serde_json",
 ]
 
 [[package]]
@@ -1405,6 +1406,7 @@ dependencies = [
  "diesel_migrations",
  "ed25519 2.2.2",
  "ed25519-dalek 2.0.0",
+ "erased-serde",
  "fission-core",
  "futures",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3959,7 +3959,7 @@ dependencies = [
 [[package]]
 name = "rs-ucan"
 version = "0.1.0"
-source = "git+https://github.com/fission-codes/rs-ucan/?branch=matheus23/expose-serde#eb58bbe1b88b0fc53facf1ee5e3e63e2919626f4"
+source = "git+https://github.com/fission-codes/rs-ucan/?branch=matheus23/allow-same-resource-scheme#5d272de3b49c233448d1e460812895c7d7f671b9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 test-log = { version = "0.2", default-features = false, features = ["trace"] }
 testresult = "0.3"
-rs-ucan = { git = "https://github.com/fission-codes/rs-ucan/", branch = "matheus23/expose-serde", revision = "7da838ec43e617c95b5ad6defa53147ed15f1caf" }
+rs-ucan = { git = "https://github.com/fission-codes/rs-ucan/", branch = "matheus23/allow-same-resource-scheme", revision = "5d272de3b49c233448d1e460812895c7d7f671b9" }
 url = "2.3"
 utoipa = { version = "3.1", features = ["uuid", "axum_extras"] }
 validator = { version = "0.16.0", features = ["derive"] }

--- a/fission-core/src/capabilities.rs
+++ b/fission-core/src/capabilities.rs
@@ -2,5 +2,6 @@
 
 pub mod did;
 pub mod fission;
+pub mod indexing;
 pub mod top;
 pub mod volume;

--- a/fission-core/src/capabilities/fission.rs
+++ b/fission-core/src/capabilities/fission.rs
@@ -29,11 +29,11 @@ pub enum FissionAbility {
     AccountDelete,
 }
 
-const ACCOUNT_READ: &'static str = "account/read";
-const ACCOUNT_CREATE: &'static str = "account/create";
-const ACCOUNT_MANAGE: &'static str = "account/manage";
-const ACCOUNT_NONCRITICAL: &'static str = "account/noncritical";
-const ACCOUNT_DELETE: &'static str = "account/delete";
+const ACCOUNT_READ: &str = "account/read";
+const ACCOUNT_CREATE: &str = "account/create";
+const ACCOUNT_MANAGE: &str = "account/manage";
+const ACCOUNT_NONCRITICAL: &str = "account/noncritical";
+const ACCOUNT_DELETE: &str = "account/delete";
 
 impl Plugin for FissionPlugin {
     type Resource = Did;

--- a/fission-core/src/capabilities/fission.rs
+++ b/fission-core/src/capabilities/fission.rs
@@ -21,7 +21,19 @@ pub enum FissionAbility {
     AccountRead,
     /// `account/create`, the ability to create an account
     AccountCreate,
+    /// `account/manage`, the ability to change e.g. the username or email address
+    AccountManage,
+    /// `account/noncritical`, any non-destructive abilities like adding data or querying data
+    AccountNonrcitical,
+    /// `account/delete`, the abilit to delete an account
+    AccountDelete,
 }
+
+const ACCOUNT_READ: &'static str = "account/read";
+const ACCOUNT_CREATE: &'static str = "account/create";
+const ACCOUNT_MANAGE: &'static str = "account/manage";
+const ACCOUNT_NONCRITICAL: &'static str = "account/noncritical";
+const ACCOUNT_DELETE: &'static str = "account/delete";
 
 impl Plugin for FissionPlugin {
     type Resource = Did;
@@ -47,8 +59,11 @@ impl Plugin for FissionPlugin {
         ability: &str,
     ) -> Result<Option<Self::Ability>, Self::Error> {
         Ok(match ability {
-            "account/read" => Some(FissionAbility::AccountRead),
-            "account/create" => Some(FissionAbility::AccountCreate),
+            ACCOUNT_READ => Some(FissionAbility::AccountRead),
+            ACCOUNT_CREATE => Some(FissionAbility::AccountCreate),
+            ACCOUNT_MANAGE => Some(FissionAbility::AccountManage),
+            ACCOUNT_NONCRITICAL => Some(FissionAbility::AccountNonrcitical),
+            ACCOUNT_DELETE => Some(FissionAbility::AccountDelete),
             _ => None,
         })
     }
@@ -67,9 +82,19 @@ impl Plugin for FissionPlugin {
 
 impl Ability for FissionAbility {
     fn is_valid_attenuation(&self, other: &dyn Ability) -> bool {
-        let Some(other) = other.downcast_ref::<FissionAbility>() else {
+        let Some(other) = other.downcast_ref::<Self>() else {
             return false;
         };
+
+        if matches!(other, Self::AccountNonrcitical) {
+            return match self {
+                Self::AccountRead => true,
+                Self::AccountCreate => true,
+                Self::AccountManage => false,
+                Self::AccountNonrcitical => true,
+                Self::AccountDelete => false,
+            };
+        }
 
         self == other
     }
@@ -78,8 +103,11 @@ impl Ability for FissionAbility {
 impl Display for FissionAbility {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(match self {
-            Self::AccountRead => "account/read",
-            Self::AccountCreate => "account/create",
+            Self::AccountRead => ACCOUNT_READ,
+            Self::AccountCreate => ACCOUNT_CREATE,
+            Self::AccountManage => ACCOUNT_MANAGE,
+            Self::AccountNonrcitical => ACCOUNT_NONCRITICAL,
+            Self::AccountDelete => ACCOUNT_DELETE,
         })
     }
 }

--- a/fission-core/src/capabilities/indexing.rs
+++ b/fission-core/src/capabilities/indexing.rs
@@ -1,0 +1,80 @@
+//! Capabilities for using the capability indexing endpoint
+
+use super::did::Did;
+use rs_ucan::{
+    plugins::Plugin,
+    semantics::{ability::Ability, caveat::EmptyCaveat},
+};
+use std::fmt::Display;
+
+/// rs_ucan plugin for handling capability abilities
+#[derive(Debug)]
+pub struct IndexingPlugin;
+
+rs_ucan::register_plugin!(INDEXING, &IndexingPlugin);
+
+/// Abilities for the UCAN and capability indexing endpoints
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IndexingAbility {
+    /// `capability/find` ability
+    Find,
+}
+
+impl Plugin for IndexingPlugin {
+    type Resource = Did;
+    type Ability = IndexingAbility;
+    type Caveat = EmptyCaveat;
+
+    type Error = anyhow::Error;
+
+    fn scheme(&self) -> &'static str {
+        "did"
+    }
+
+    fn try_handle_resource(
+        &self,
+        resource_uri: &url::Url,
+    ) -> std::result::Result<Option<Self::Resource>, Self::Error> {
+        Ok(Did::try_handle_as_resource(resource_uri))
+    }
+
+    fn try_handle_ability(
+        &self,
+        _resource: &Self::Resource,
+        ability: &str,
+    ) -> std::result::Result<Option<Self::Ability>, Self::Error> {
+        Ok(match ability {
+            "capability/find" => Some(IndexingAbility::Find),
+            _ => None,
+        })
+    }
+
+    fn try_handle_caveat(
+        &self,
+        _resource: &Self::Resource,
+        _ability: &Self::Ability,
+        deserializer: &mut dyn erased_serde::Deserializer<'_>,
+    ) -> std::result::Result<Option<Self::Caveat>, Self::Error> {
+        Ok(Some(
+            erased_serde::deserialize(deserializer).map_err(|e| anyhow::anyhow!(e))?,
+        ))
+    }
+}
+
+impl Ability for IndexingAbility {
+    fn is_valid_attenuation(&self, other: &dyn Ability) -> bool {
+        let Some(other) = other.downcast_ref::<IndexingAbility>() else {
+            return false;
+        };
+
+        self == other
+    }
+}
+
+impl Display for IndexingAbility {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Find => "capability/find",
+        })
+    }
+}

--- a/fission-core/src/capabilities/indexing.rs
+++ b/fission-core/src/capabilities/indexing.rs
@@ -16,9 +16,11 @@ rs_ucan::register_plugin!(INDEXING, &IndexingPlugin);
 /// Abilities for the UCAN and capability indexing endpoints
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IndexingAbility {
-    /// `capability/find` ability
-    Find,
+    /// `capability/fetch` ability
+    Fetch,
 }
+
+const CAPABILITY_FETCH: &str = "capability/fetch";
 
 impl Plugin for IndexingPlugin {
     type Resource = Did;
@@ -44,7 +46,7 @@ impl Plugin for IndexingPlugin {
         ability: &str,
     ) -> std::result::Result<Option<Self::Ability>, Self::Error> {
         Ok(match ability {
-            "capability/find" => Some(IndexingAbility::Find),
+            CAPABILITY_FETCH => Some(IndexingAbility::Fetch),
             _ => None,
         })
     }
@@ -74,7 +76,7 @@ impl Ability for IndexingAbility {
 impl Display for IndexingAbility {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(match self {
-            Self::Find => "capability/find",
+            Self::Fetch => CAPABILITY_FETCH,
         })
     }
 }

--- a/fission-core/src/common.rs
+++ b/fission-core/src/common.rs
@@ -1,5 +1,6 @@
 //! Request and response data types that are common and useful between clients of and the fission server
 
+use rs_ucan::ucan::Ucan;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use validator::Validate;
@@ -45,4 +46,11 @@ pub struct DidResponse {
 pub struct SuccessResponse {
     /// Whether the response was successful
     pub success: bool,
+}
+
+/// Response type containing UCANs
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
+pub struct UcansResponse {
+    /// A list of UCANs returned from the request
+    pub ucans: Vec<Ucan>,
 }

--- a/fission-server/Cargo.toml
+++ b/fission-server/Cargo.toml
@@ -49,7 +49,7 @@ console-subscriber = { version = "0.1", default-features = false, features = [ "
 const_format = "0.2"
 dashmap = "5.5.0"
 did-key = "0.2.1"
-diesel = { version = "2.0.4", features = ["postgres", "chrono"] }
+diesel = { version = "2.0.4", features = ["postgres", "chrono", "serde_json"] }
 diesel-async = { version = "0.3", features = ["bb8", "postgres"] }
 diesel_migrations = "2.1"
 fission-core = { path = "../fission-core", version = "0.1" }
@@ -110,6 +110,7 @@ ed25519 = { workspace = true }
 ed25519-dalek = { workspace = true }
 libipld = "0.16.0"
 blake3 = "1.4.1"
+erased-serde = "0.3.31"
 
 [dev-dependencies]
 assert-json-diff = "2.0"

--- a/fission-server/migrations/2023-10-23-163251_ucans_indexer/down.sql
+++ b/fission-server/migrations/2023-10-23-163251_ucans_indexer/down.sql
@@ -1,0 +1,8 @@
+DROP INDEX idx_capabilities_resource;
+DROP INDEX idx_capabilities_ability;
+DROP TABLE capabilities;
+
+DROP INDEX idx_ucans_cid;
+DROP INDEX idx_ucans_issuer;
+DROP INDEX idx_ucans_audience;
+DROP TABLE ucans;

--- a/fission-server/migrations/2023-10-23-163251_ucans_indexer/up.sql
+++ b/fission-server/migrations/2023-10-23-163251_ucans_indexer/up.sql
@@ -1,7 +1,7 @@
 CREATE TABLE ucans (
     id SERIAL PRIMARY KEY,
-    cid BYTEA NOT NULL UNIQUE,
-    encoded BYTEA NOT NULL,
+    cid TEXT NOT NULL UNIQUE,
+    encoded TEXT NOT NULL,
 
     issuer TEXT NOT NULL,
     audience TEXT NOT NULL,

--- a/fission-server/migrations/2023-10-23-163251_ucans_indexer/up.sql
+++ b/fission-server/migrations/2023-10-23-163251_ucans_indexer/up.sql
@@ -25,7 +25,9 @@ CREATE TABLE capabilities (
 
     caveats JSONB NOT NULL,
 
-    ucan_id INTEGER NOT NULL REFERENCES ucans(id)
+    ucan_id INTEGER NOT NULL
+        REFERENCES ucans(id)
+        ON DELETE CASCADE
 );
 
 CREATE INDEX idx_capabilities_resource ON capabilities (resource);

--- a/fission-server/migrations/2023-10-23-163251_ucans_indexer/up.sql
+++ b/fission-server/migrations/2023-10-23-163251_ucans_indexer/up.sql
@@ -1,0 +1,33 @@
+CREATE TABLE ucans (
+    id SERIAL PRIMARY KEY,
+    cid BYTEA NOT NULL UNIQUE,
+    encoded BYTEA NOT NULL,
+
+    issuer TEXT NOT NULL,
+    audience TEXT NOT NULL,
+
+    not_before TIMESTAMP,
+    expires_at TIMESTAMP
+);
+
+CREATE UNIQUE INDEX idx_ucans_cid ON ucans (cid);
+
+CREATE INDEX idx_ucans_issuer ON ucans (issuer);
+
+CREATE INDEX idx_ucans_audience ON ucans (audience);
+
+
+CREATE TABLE capabilities (
+    id SERIAL PRIMARY KEY,
+
+    resource TEXT NOT NULL,
+    ability TEXT NOT NULL,
+
+    caveats JSONB NOT NULL,
+
+    ucan_id INTEGER NOT NULL REFERENCES ucans(id)
+);
+
+CREATE INDEX idx_capabilities_resource ON capabilities (resource);
+
+CREATE INDEX idx_capabilities_ability ON capabilities (ability);

--- a/fission-server/src/db/connection.rs
+++ b/fission-server/src/db/connection.rs
@@ -8,7 +8,6 @@ use diesel::{ExpressionMethods, OptionalExtension, QueryDsl};
 use diesel_async::{
     pooled_connection::AsyncDieselConnectionManager, AsyncPgConnection, RunQueryDsl,
 };
-use tracing::log;
 
 // 🧬
 
@@ -22,10 +21,10 @@ pub type Conn<'a> = PooledConnection<'a, AsyncDieselConnectionManager<AsyncPgCon
 
 /// Build the database pool
 pub async fn pool(url: &str, connect_timeout: u64) -> Result<Pool> {
-    log::info!(
-        "Connecting to database: {}, connect_timeout={}",
-        &url,
-        connect_timeout
+    tracing::info!(
+        %url,
+        %connect_timeout,
+        "Connecting to database via pool",
     );
 
     let config = AsyncDieselConnectionManager::<diesel_async::AsyncPgConnection>::new(url);
@@ -41,10 +40,10 @@ pub async fn pool(url: &str, connect_timeout: u64) -> Result<Pool> {
 
 /// Establish a connection
 pub async fn connect(pool: &Pool) -> Result<Conn<'_>> {
-    log::debug!("Connecting to the database");
+    tracing::debug!("Creating a db connection from connection pool");
     pool.get()
         .await
-        .map_err(|_| anyhow::anyhow!("Failed to connect to database"))
+        .map_err(|e| anyhow::anyhow!("Failed to connect to the database: {e}"))
 }
 
 /// Get the current schema version

--- a/fission-server/src/db/schema.rs
+++ b/fission-server/src/db/schema.rs
@@ -24,12 +24,34 @@ diesel::table! {
 }
 
 diesel::table! {
+    capabilities (id) {
+        id -> Int4,
+        resource -> Text,
+        ability -> Text,
+        caveats -> Jsonb,
+        ucan_id -> Int4,
+    }
+}
+
+diesel::table! {
     email_verifications (id) {
         id -> Int4,
         inserted_at -> Timestamp,
         updated_at -> Timestamp,
         email -> Text,
         code -> Text,
+    }
+}
+
+diesel::table! {
+    ucans (id) {
+        id -> Int4,
+        cid -> Bytea,
+        encoded -> Bytea,
+        issuer -> Text,
+        audience -> Text,
+        not_before -> Nullable<Timestamp>,
+        expires_at -> Nullable<Timestamp>,
     }
 }
 
@@ -45,5 +67,13 @@ diesel::table! {
 diesel::joinable!(accounts -> volumes (volume_id));
 diesel::joinable!(apps -> accounts (owner_id));
 diesel::joinable!(apps -> volumes (volume_id));
+diesel::joinable!(capabilities -> ucans (ucan_id));
 
-diesel::allow_tables_to_appear_in_same_query!(accounts, apps, email_verifications, volumes,);
+diesel::allow_tables_to_appear_in_same_query!(
+    accounts,
+    apps,
+    capabilities,
+    email_verifications,
+    ucans,
+    volumes,
+);

--- a/fission-server/src/db/schema.rs
+++ b/fission-server/src/db/schema.rs
@@ -46,8 +46,8 @@ diesel::table! {
 diesel::table! {
     ucans (id) {
         id -> Int4,
-        cid -> Bytea,
-        encoded -> Bytea,
+        cid -> Text,
+        encoded -> Text,
         issuer -> Text,
         audience -> Text,
         not_before -> Nullable<Timestamp>,

--- a/fission-server/src/models/capability_indexing.rs
+++ b/fission-server/src/models/capability_indexing.rs
@@ -170,10 +170,17 @@ pub async fn find_ucans_for_audience(audience: String, conn: &mut Conn<'_>) -> R
     let mut audience_dids_frontier = BTreeSet::from([audience]);
 
     loop {
+        tracing::debug!(
+            visited_ids_set = ?visited_ids_set,
+            audience_dids_frontier = ?audience_dids_frontier,
+            "UCAN graph search iteration"
+        );
+
         let ids_and_issuers: Vec<(i32, String)> = ucans::table
             .filter(ucans::dsl::audience.eq_any(&audience_dids_frontier))
             .filter(ucans::dsl::id.ne_all(&visited_ids_set))
             // TODO Also filter by not_before & expires_at
+            // TODO only follow edges when they have a common resource/the resource is subsumed
             .select((ucans::dsl::id, ucans::dsl::issuer))
             .get_results(conn)
             .await?;
@@ -189,6 +196,8 @@ pub async fn find_ucans_for_audience(audience: String, conn: &mut Conn<'_>) -> R
             audience_dids_frontier.insert(issuer);
         }
     }
+
+    tracing::debug!(visited_ids_set = ?visited_ids_set, "Finished UCAN graph search");
 
     let indexed_ucans = ucans::table
         .filter(ucans::dsl::id.eq_any(&visited_ids_set))

--- a/fission-server/src/models/capability_indexing.rs
+++ b/fission-server/src/models/capability_indexing.rs
@@ -1,10 +1,12 @@
 //! Models related to capability indexing, specifically the `ucans` and `capabilities` table.
 
+use std::{collections::BTreeSet, str::FromStr};
+
 use crate::db::{
     schema::{capabilities, ucans},
     Conn,
 };
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use chrono::NaiveDateTime;
 use cid::{
     multihash::{Code, MultihashDigest},
@@ -12,7 +14,7 @@ use cid::{
 };
 use diesel::{
     pg::Pg, Associations, ExpressionMethods, Identifiable, Insertable, OptionalExtension, QueryDsl,
-    Queryable, Selectable,
+    Queryable, Selectable, SelectableHelper,
 };
 use diesel_async::RunQueryDsl;
 use rs_ucan::{capability::Capability, ucan::Ucan};
@@ -31,9 +33,30 @@ pub struct IndexedUcan {
     pub id: i32,
 
     /// SHA2-256 raw CID of the encoded token
-    pub cid: Vec<u8>,
+    pub cid: String,
     /// Token in encoded format
-    pub encoded: Vec<u8>,
+    pub encoded: String,
+
+    /// UCAN `iss` field
+    pub issuer: String,
+    /// UCAN `aud` field
+    pub audience: String,
+
+    /// UCAN `nbf` field
+    pub not_before: Option<NaiveDateTime>,
+    /// UCAN `exp` field
+    pub expires_at: Option<NaiveDateTime>,
+}
+
+/// Represents an indexed UCAN that wasn't added to the database yet
+#[derive(Debug, Clone, Queryable, Selectable, Insertable, Serialize, Deserialize, ToSchema)]
+#[diesel(table_name = ucans)]
+#[diesel(check_for_backend(Pg))]
+pub struct NewIndexedUcan {
+    /// SHA2-256 raw CID of the encoded token
+    pub cid: String,
+    /// Token in encoded format
+    pub encoded: String,
 
     /// UCAN `iss` field
     pub issuer: String,
@@ -78,6 +101,26 @@ pub struct IndexedCapability {
     pub ucan_id: i32,
 }
 
+/// Represents an indexed capability that hasn't been added to the database yet
+#[derive(
+    Debug, Clone, Queryable, Selectable, Insertable, Associations, Serialize, Deserialize, ToSchema,
+)]
+#[diesel(belongs_to(IndexedUcan, foreign_key = ucan_id))]
+#[diesel(table_name = capabilities)]
+#[diesel(check_for_backend(Pg))]
+pub struct NewIndexedCapability {
+    /// Capability resource. For our purposes this will always be a DID.
+    pub resource: String,
+    /// Capability's ability
+    pub ability: String,
+
+    /// Any caveats. 'No caveats' would be `[{}]`
+    pub caveats: Value,
+
+    /// DB id of the UCAN that this capability is contained in
+    pub ucan_id: i32,
+}
+
 /// Index a UCAN in the database.
 /// Should be idempotent.
 pub async fn index_ucan(ucan: &Ucan, conn: &mut Conn<'_>) -> Result<IndexedUcan> {
@@ -85,32 +128,32 @@ pub async fn index_ucan(ucan: &Ucan, conn: &mut Conn<'_>) -> Result<IndexedUcan>
 
     // TODO only index UCANs & their capabilities, if they've been proven!
 
-    let mut indexed_ucan = IndexedUcan::new(ucan)?;
+    let new_indexed_ucan = NewIndexedUcan::new(ucan)?;
 
     let existing_ucan_id: Option<i32> = ucans::table
-        .filter(ucans::dsl::cid.eq(&indexed_ucan.cid))
+        .filter(ucans::dsl::cid.eq(&new_indexed_ucan.cid))
         .select(ucans::dsl::id)
         .get_result::<i32>(conn)
         .await
         .optional()?;
 
-    // We short-circuit if we've stored this before
+    // We short-circuit if we've stored this before, since then we'd have
+    // stored the capabilities as well.
     if let Some(ucan_id) = existing_ucan_id {
-        indexed_ucan.id = ucan_id;
-        return Ok(indexed_ucan);
+        return Ok(IndexedUcan::new(new_indexed_ucan, ucan_id));
     }
 
     let ucan_id = diesel::insert_into(ucans::table)
-        .values(&indexed_ucan)
+        .values(&new_indexed_ucan)
         .returning(ucans::dsl::id)
         .get_result(conn)
         .await?;
 
-    indexed_ucan.id = ucan_id;
+    let indexed_ucan = IndexedUcan::new(new_indexed_ucan, ucan_id);
 
     let capabilities = ucan
         .capabilities()
-        .map(|cap| IndexedCapability::new(cap, ucan_id))
+        .map(|cap| NewIndexedCapability::new(cap, ucan_id))
         .collect::<Result<Vec<_>>>()?;
 
     diesel::insert_into(capabilities::table)
@@ -121,9 +164,49 @@ pub async fn index_ucan(ucan: &Ucan, conn: &mut Conn<'_>) -> Result<IndexedUcan>
     Ok(indexed_ucan)
 }
 
-impl IndexedUcan {
+/// Fetch all indexed UCANs that end in a specific audience
+pub async fn find_ucans_for_audience(audience: String, conn: &mut Conn<'_>) -> Result<Vec<Ucan>> {
+    let mut visited_ids_set = BTreeSet::<i32>::new();
+    let mut audience_dids_frontier = BTreeSet::from([audience]);
+
+    loop {
+        let ids_and_issuers: Vec<(i32, String)> = ucans::table
+            .filter(ucans::dsl::audience.eq_any(&audience_dids_frontier))
+            .filter(ucans::dsl::id.ne_all(&visited_ids_set))
+            // TODO Also filter by not_before & expires_at
+            .select((ucans::dsl::id, ucans::dsl::issuer))
+            .get_results(conn)
+            .await?;
+
+        if ids_and_issuers.is_empty() {
+            break;
+        }
+
+        audience_dids_frontier.clear();
+
+        for (id, issuer) in ids_and_issuers {
+            visited_ids_set.insert(id);
+            audience_dids_frontier.insert(issuer);
+        }
+    }
+
+    let indexed_ucans = ucans::table
+        .filter(ucans::dsl::id.eq_any(&visited_ids_set))
+        .select(IndexedUcan::as_select())
+        .get_results(conn)
+        .await?;
+
+    let ucans = indexed_ucans
+        .into_iter()
+        .map(|ucan| Ucan::from_str(&ucan.encoded).map_err(|e| anyhow!(e)))
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(ucans)
+}
+
+impl NewIndexedUcan {
     fn new(ucan: &Ucan) -> Result<Self> {
-        let encoded = ucan.encode()?.as_bytes().to_vec();
+        let encoded = ucan.encode()?;
         let issuer = ucan.issuer().to_string();
         let audience = ucan.audience().to_string();
 
@@ -135,12 +218,11 @@ impl IndexedUcan {
             .expires_at()
             .and_then(|seconds| NaiveDateTime::from_timestamp_millis((seconds * 1000) as i64));
 
-        let hash = Code::Sha2_256.digest(&encoded);
+        let hash = Code::Sha2_256.digest(encoded.as_bytes());
         // 0x55 is the raw codec
-        let cid = Cid::new_v1(0x55, hash).to_bytes();
+        let cid = Cid::new_v1(0x55, hash).to_string();
 
         Ok(Self {
-            id: 0,
             cid,
             encoded,
             issuer,
@@ -151,18 +233,58 @@ impl IndexedUcan {
     }
 }
 
-impl IndexedCapability {
+impl NewIndexedCapability {
     fn new(cap: &Capability, ucan_id: i32) -> Result<Self> {
         let resource = cap.resource().to_string();
         let ability = cap.ability().to_string();
         let caveats = cap.caveat().serialize(serde_json::value::Serializer)?;
 
         Ok(Self {
-            id: 0,
             resource,
             ability,
             caveats,
             ucan_id,
         })
+    }
+}
+
+impl IndexedUcan {
+    fn new(new_ucan: NewIndexedUcan, id: i32) -> Self {
+        let NewIndexedUcan {
+            cid,
+            encoded,
+            issuer,
+            audience,
+            not_before,
+            expires_at,
+        } = new_ucan;
+        Self {
+            id,
+            cid,
+            encoded,
+            issuer,
+            audience,
+            not_before,
+            expires_at,
+        }
+    }
+}
+
+impl IndexedCapability {
+    #[allow(unused)]
+    fn new(new_cap: NewIndexedCapability, id: i32) -> Self {
+        let NewIndexedCapability {
+            resource,
+            ability,
+            caveats,
+            ucan_id,
+        } = new_cap;
+        Self {
+            id,
+            resource,
+            ability,
+            caveats,
+            ucan_id,
+        }
     }
 }

--- a/fission-server/src/models/capability_indexing.rs
+++ b/fission-server/src/models/capability_indexing.rs
@@ -1,0 +1,168 @@
+//! Models related to capability indexing, specifically the `ucans` and `capabilities` table.
+
+use crate::db::{
+    schema::{capabilities, ucans},
+    Conn,
+};
+use anyhow::Result;
+use chrono::NaiveDateTime;
+use cid::{
+    multihash::{Code, MultihashDigest},
+    Cid,
+};
+use diesel::{
+    pg::Pg, Associations, ExpressionMethods, Identifiable, Insertable, OptionalExtension, QueryDsl,
+    Queryable, Selectable,
+};
+use diesel_async::RunQueryDsl;
+use rs_ucan::{capability::Capability, ucan::Ucan};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use utoipa::ToSchema;
+
+/// Represents an indexed UCAN in the database
+#[derive(
+    Debug, Clone, Queryable, Selectable, Insertable, Identifiable, Serialize, Deserialize, ToSchema,
+)]
+#[diesel(table_name = ucans)]
+#[diesel(check_for_backend(Pg))]
+pub struct IndexedUcan {
+    /// Internal DB id
+    pub id: i32,
+
+    /// SHA2-256 raw CID of the encoded token
+    pub cid: Vec<u8>,
+    /// Token in encoded format
+    pub encoded: Vec<u8>,
+
+    /// UCAN `iss` field
+    pub issuer: String,
+    /// UCAN `aud` field
+    pub audience: String,
+
+    /// UCAN `nbf` field
+    pub not_before: Option<NaiveDateTime>,
+    /// UCAN `exp` field
+    pub expires_at: Option<NaiveDateTime>,
+}
+
+/// Represents a database row of an indexed capability
+#[derive(
+    Debug,
+    Clone,
+    Queryable,
+    Selectable,
+    Insertable,
+    Identifiable,
+    Associations,
+    Serialize,
+    Deserialize,
+    ToSchema,
+)]
+#[diesel(belongs_to(IndexedUcan, foreign_key = ucan_id))]
+#[diesel(table_name = capabilities)]
+#[diesel(check_for_backend(Pg))]
+pub struct IndexedCapability {
+    /// Internal DB id
+    pub id: i32,
+
+    /// Capability resource. For our purposes this will always be a DID.
+    pub resource: String,
+    /// Capability's ability
+    pub ability: String,
+
+    /// Any caveats. 'No caveats' would be `[{}]`
+    pub caveats: Value,
+
+    /// DB id of the UCAN that this capability is contained in
+    pub ucan_id: i32,
+}
+
+/// Index a UCAN in the database.
+/// Should be idempotent.
+pub async fn index_ucan(ucan: &Ucan, conn: &mut Conn<'_>) -> Result<IndexedUcan> {
+    use crate::db::schema::*;
+
+    // TODO only index UCANs & their capabilities, if they've been proven!
+
+    let mut indexed_ucan = IndexedUcan::new(ucan)?;
+
+    let existing_ucan_id: Option<i32> = ucans::table
+        .filter(ucans::dsl::cid.eq(&indexed_ucan.cid))
+        .select(ucans::dsl::id)
+        .get_result::<i32>(conn)
+        .await
+        .optional()?;
+
+    // We short-circuit if we've stored this before
+    if let Some(ucan_id) = existing_ucan_id {
+        indexed_ucan.id = ucan_id;
+        return Ok(indexed_ucan);
+    }
+
+    let ucan_id = diesel::insert_into(ucans::table)
+        .values(&indexed_ucan)
+        .returning(ucans::dsl::id)
+        .get_result(conn)
+        .await?;
+
+    indexed_ucan.id = ucan_id;
+
+    let capabilities = ucan
+        .capabilities()
+        .map(|cap| IndexedCapability::new(cap, ucan_id))
+        .collect::<Result<Vec<_>>>()?;
+
+    diesel::insert_into(capabilities::table)
+        .values(&capabilities)
+        .execute(conn)
+        .await?;
+
+    Ok(indexed_ucan)
+}
+
+impl IndexedUcan {
+    fn new(ucan: &Ucan) -> Result<Self> {
+        let encoded = ucan.encode()?.as_bytes().to_vec();
+        let issuer = ucan.issuer().to_string();
+        let audience = ucan.audience().to_string();
+
+        let not_before = ucan
+            .not_before()
+            .and_then(|seconds| NaiveDateTime::from_timestamp_millis((seconds * 1000) as i64));
+
+        let expires_at = ucan
+            .expires_at()
+            .and_then(|seconds| NaiveDateTime::from_timestamp_millis((seconds * 1000) as i64));
+
+        let hash = Code::Sha2_256.digest(&encoded);
+        // 0x55 is the raw codec
+        let cid = Cid::new_v1(0x55, hash).to_bytes();
+
+        Ok(Self {
+            id: 0,
+            cid,
+            encoded,
+            issuer,
+            audience,
+            not_before,
+            expires_at,
+        })
+    }
+}
+
+impl IndexedCapability {
+    fn new(cap: &Capability, ucan_id: i32) -> Result<Self> {
+        let resource = cap.resource().to_string();
+        let ability = cap.ability().to_string();
+        let caveats = cap.caveat().serialize(serde_json::value::Serializer)?;
+
+        Ok(Self {
+            id: 0,
+            resource,
+            ability,
+            caveats,
+            ucan_id,
+        })
+    }
+}

--- a/fission-server/src/models/mod.rs
+++ b/fission-server/src/models/mod.rs
@@ -1,5 +1,6 @@
 //! This module contains all the models used in the application.
 pub mod account;
 pub mod app;
+pub mod capability_indexing;
 pub mod email_verification;
 pub mod volume;

--- a/fission-server/src/router.rs
+++ b/fission-server/src/router.rs
@@ -9,7 +9,7 @@ use crate::{
     traits::ServerSetup,
 };
 use axum::{
-    routing::{get, post},
+    routing::{delete, get, patch, post},
     Router,
 };
 use tower_http::cors::{Any, CorsLayer};
@@ -39,7 +39,12 @@ pub fn setup_app_router<S: ServerSetup + 'static>(app_state: AppState<S>) -> Rou
         .route("/auth/email/verify", post(auth::request_token))
         .route("/server-did", get(auth::server_did))
         .route("/account", post(account::create_account))
+        .route("/account", delete(account::delete_account))
         .route("/account/:did", get(account::get_account))
+        .route(
+            "/account/username/:username",
+            patch(account::patch_username),
+        )
         .route("/account/:username/did", get(account::get_did))
         .route("/capabilities", get(capability_indexing::get_capabilities))
         .with_state(app_state.clone())

--- a/fission-server/src/router.rs
+++ b/fission-server/src/router.rs
@@ -3,10 +3,11 @@
 use crate::{
     app_state::AppState,
     middleware::logging::{log_request_response, DebugOnlyLogger, Logger},
-    routes::{account, auth, doh, fallback::notfound_404, health, ipfs, ping, ws},
+    routes::{
+        account, auth, capability_indexing, doh, fallback::notfound_404, health, ipfs, ping, ws,
+    },
     traits::ServerSetup,
 };
-
 use axum::{
     routing::{get, post},
     Router,
@@ -40,6 +41,7 @@ pub fn setup_app_router<S: ServerSetup + 'static>(app_state: AppState<S>) -> Rou
         .route("/account", post(account::create_account))
         .route("/account/:did", get(account::get_account))
         .route("/account/:username/did", get(account::get_did))
+        .route("/capabilities", get(capability_indexing::get_capabilities))
         .with_state(app_state.clone())
         .fallback(notfound_404);
 

--- a/fission-server/src/routes/account.rs
+++ b/fission-server/src/routes/account.rs
@@ -208,7 +208,10 @@ pub async fn delete_account<S: ServerSetup>(
                 .optional()?;
 
             let Some(account) = row else {
-                return Err(AppError::new(StatusCode::NOT_FOUND, Some("Couldn't find an account with this DID.")));
+                return Err(AppError::new(
+                    StatusCode::NOT_FOUND,
+                    Some("Couldn't find an account with this DID.")
+                ));
             };
 
             let indexed_caps: Vec<IndexedCapability> = capabilities::table

--- a/fission-server/src/routes/account.rs
+++ b/fission-server/src/routes/account.rs
@@ -210,7 +210,7 @@ pub async fn delete_account<S: ServerSetup>(
             let Some(account) = row else {
                 return Err(AppError::new(
                     StatusCode::NOT_FOUND,
-                    Some("Couldn't find an account with this DID.")
+                    Some("Couldn't find an account with this DID."),
                 ));
             };
 

--- a/fission-server/src/routes/auth.rs
+++ b/fission-server/src/routes/auth.rs
@@ -188,4 +188,22 @@ mod tests {
 
         Ok(())
     }
+
+    #[test_log::test(tokio::test)]
+    async fn test_get_server_did() -> TestResult {
+        let ctx = TestContext::new().await;
+
+        let (status, bytes) =
+            RouteBuilder::<DefaultFact>::new(ctx.app(), Method::GET, "/api/v0/server-did")
+                .into_raw_response()
+                .await?;
+
+        assert_eq!(status, StatusCode::OK);
+
+        let parsed = String::from_utf8(bytes.to_vec())?;
+
+        assert_eq!(parsed, ctx.app_state().did.did());
+
+        Ok(())
+    }
 }

--- a/fission-server/src/routes/auth.rs
+++ b/fission-server/src/routes/auth.rs
@@ -73,7 +73,7 @@ mod tests {
         routes::auth::SuccessResponse,
         test_utils::{test_context::TestContext, RouteBuilder},
     };
-    use anyhow::anyhow;
+    use anyhow::{anyhow, Result};
     use assert_matches::assert_matches;
     use chrono::{Duration, Local};
     use diesel_async::RunQueryDsl;
@@ -82,24 +82,30 @@ mod tests {
     use serde_json::json;
     use testresult::TestResult;
 
-    #[test_log::test(tokio::test)]
-    async fn test_request_code_ok() -> TestResult {
-        let ctx = TestContext::new().await;
-
-        let email = "oedipa@trystero.com";
-
+    async fn request_code(email: &str, ctx: &TestContext) -> Result<(StatusCode, String, String)> {
         let (status, _) =
             RouteBuilder::<DefaultFact>::new(ctx.app(), Method::POST, "/api/v0/auth/email/verify")
                 .with_json_body(json!({ "email": email }))?
                 .into_json_response::<SuccessResponse>()
                 .await?;
 
-        let (email, _) = ctx
+        let (email_address, email_code) = ctx
             .verification_code_sender()
             .get_emails()
             .into_iter()
             .last()
             .expect("No email sent");
+
+        Ok((status, email_address, email_code))
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_request_code_ok() -> TestResult {
+        let ctx = TestContext::new().await;
+
+        let email = "oedipa@trystero.com";
+
+        let (status, email, _) = request_code(email, &ctx).await?;
 
         assert_eq!(status, StatusCode::OK);
         assert_eq!(email, "oedipa@trystero.com");
@@ -113,17 +119,7 @@ mod tests {
 
         let email = "oedipa@trystero.com";
 
-        RouteBuilder::<DefaultFact>::new(ctx.app(), Method::POST, "/api/v0/auth/email/verify")
-            .with_json_body(json!({ "email": email }))?
-            .into_json_response::<SuccessResponse>()
-            .await?;
-
-        let (_, code) = ctx
-            .verification_code_sender()
-            .get_emails()
-            .into_iter()
-            .last()
-            .expect("No email sent");
+        let (_, _, code) = request_code(email, &ctx).await?;
 
         let token_result =
             EmailVerification::find_token(&mut ctx.get_db_conn().await, email, &code).await;
@@ -167,6 +163,28 @@ mod tests {
         let token_result = EmailVerification::find_token(&mut conn, email, code).await;
 
         assert_matches!(token_result, Err(_));
+
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_request_code_consumed() -> TestResult {
+        let ctx = TestContext::new().await;
+        let conn = &mut ctx.get_db_conn().await;
+
+        let email = "oedipa@trystero.com";
+
+        let (_, _, code) = request_code(email, &ctx).await?;
+
+        let token = EmailVerification::find_token(conn, email, &code).await?;
+
+        assert_eq!(&token.email, email);
+
+        token.consume_token(conn).await?;
+
+        let result = EmailVerification::find_token(conn, email, &code).await;
+
+        assert_matches!(result, Err(_));
 
         Ok(())
     }

--- a/fission-server/src/routes/capability_indexing.rs
+++ b/fission-server/src/routes/capability_indexing.rs
@@ -51,3 +51,168 @@ pub async fn get_capabilities<S: ServerSetup>(
     })
     .await
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        db::Conn,
+        error::ErrorResponse,
+        models::capability_indexing::index_ucan,
+        test_utils::{test_context::TestContext, RouteBuilder},
+    };
+    use anyhow::Result;
+    use assert_matches::assert_matches;
+    use fission_core::{capabilities::did::Did, ed_did_key::EdDidKey};
+    use http::Method;
+    use rs_ucan::{
+        builder::UcanBuilder,
+        capability::Capability,
+        semantics::{ability::TopAbility, caveat::EmptyCaveat},
+        ucan::Ucan,
+        DefaultFact,
+    };
+    use testresult::TestResult;
+
+    async fn index_test_ucan(
+        issuer: &EdDidKey,
+        audience: &EdDidKey,
+        conn: &mut Conn<'_>,
+    ) -> Result<Ucan> {
+        let ucan: Ucan = UcanBuilder::default()
+            .issued_by(issuer)
+            .for_audience(audience)
+            .claiming_capability(Capability::new(Did(issuer.did()), TopAbility, EmptyCaveat))
+            .sign(issuer)?;
+
+        index_ucan(&ucan, conn).await?;
+
+        Ok(ucan)
+    }
+
+    async fn fetch_capabilities(
+        requestor: &EdDidKey,
+        ctx: &TestContext,
+    ) -> Result<(StatusCode, UcansResponse)> {
+        let auth: Ucan = UcanBuilder::default()
+            .issued_by(requestor)
+            .for_audience(ctx.server_did())
+            .claiming_capability(Capability::new(
+                Did(requestor.did()),
+                IndexingAbility::Fetch,
+                EmptyCaveat,
+            ))
+            .sign(requestor)?;
+
+        let (status, response) =
+            RouteBuilder::<DefaultFact>::new(ctx.app(), Method::GET, "/api/v0/capabilities")
+                .with_ucan(auth)
+                .into_json_response::<UcansResponse>()
+                .await?;
+
+        Ok((status, response))
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_get_capabilities_ok() -> TestResult {
+        let ctx = TestContext::new().await;
+        let conn = &mut ctx.get_db_conn().await;
+
+        let device = &EdDidKey::generate();
+        let server = ctx.server_did();
+
+        let ucan = index_test_ucan(server, device, conn).await?;
+
+        let (status, response) = fetch_capabilities(device, &ctx).await?;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_matches!(&response.ucans[..], [one_ucan] if one_ucan.encode().unwrap() == ucan.encode().unwrap());
+
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_get_capabilities_unauthorized() -> TestResult {
+        let ctx = TestContext::new().await;
+        let conn = &mut ctx.get_db_conn().await;
+
+        let device = &EdDidKey::generate();
+        let server = ctx.server_did();
+
+        let ucan: Ucan = UcanBuilder::default()
+            .issued_by(server)
+            .for_audience(device)
+            .claiming_capability(Capability::new(Did(server.did()), TopAbility, EmptyCaveat))
+            .sign(server)?;
+
+        index_ucan(&ucan, conn).await?;
+
+        let (status, _) =
+            RouteBuilder::<DefaultFact>::new(ctx.app(), Method::GET, "/api/v0/capabilities")
+                .into_json_response::<ErrorResponse>()
+                .await?;
+
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_get_capabilities_filtered_by_audience() -> TestResult {
+        let ctx = TestContext::new().await;
+        let conn = &mut ctx.get_db_conn().await;
+
+        let device = &EdDidKey::generate();
+        let device_other = &EdDidKey::generate();
+        let server = ctx.server_did();
+
+        // Index a test UCAN from `server` -> `device_other`
+        let ucan_other = index_test_ucan(server, device_other, conn).await?;
+        // Requesting UCANs delegated to `device` should end up empty
+        let (status, response) = fetch_capabilities(device, &ctx).await?;
+
+        assert_eq!(status, StatusCode::OK);
+        assert!(response.ucans.is_empty());
+
+        // Index a test UCAN from `server` -> `device` this time
+        let ucan = index_test_ucan(server, device, conn).await?;
+
+        // Requesting UCANs should only return the ones that end in the relevant issuer's DID
+        let (_, response) = fetch_capabilities(device, &ctx).await?;
+        let (_, response_other) = fetch_capabilities(device_other, &ctx).await?;
+
+        assert_matches!(&response.ucans[..], [u] if u.encode().unwrap() == ucan.encode().unwrap());
+        assert_matches!(&response_other.ucans[..], [u] if u.encode().unwrap() == ucan_other.encode().unwrap());
+
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_get_capabilities_fetches_whole_chain() -> TestResult {
+        let ctx = TestContext::new().await;
+        let conn = &mut ctx.get_db_conn().await;
+
+        let id_one = &EdDidKey::generate();
+        let id_two = &EdDidKey::generate();
+        let server = ctx.server_did();
+
+        let ucan_one = index_test_ucan(server, id_one, conn).await?;
+        let ucan_two = index_test_ucan(id_one, id_two, conn).await?;
+
+        let (status, response) = fetch_capabilities(id_two, &ctx).await?;
+
+        // We currently allow it to fetch the whole chain, ignoring
+        // the `prf` UCAN field altogether.
+        // In the future, when the `prf` field is removed, this will make
+        // a lot more sense.
+        assert_eq!(status, StatusCode::OK);
+        assert_matches!(
+            &response.ucans[..],
+            [u1, u2] if
+                u1.encode().unwrap() == ucan_one.encode().unwrap()
+                && u2.encode().unwrap() == ucan_two.encode().unwrap()
+        );
+
+        Ok(())
+    }
+}

--- a/fission-server/src/routes/capability_indexing.rs
+++ b/fission-server/src/routes/capability_indexing.rs
@@ -1,0 +1,53 @@
+//! Routes for the capability indexing endpoints
+
+use axum::extract::State;
+use diesel_async::{scoped_futures::ScopedFutureExt, AsyncConnection};
+use fission_core::{
+    capabilities::{did::Did, indexing::IndexingAbility},
+    common::UcansResponse,
+};
+use http::StatusCode;
+
+use crate::{
+    app_state::AppState,
+    authority::Authority,
+    db,
+    error::{AppError, AppResult},
+    extract::json::Json,
+    models::capability_indexing::find_ucans_for_audience,
+    traits::ServerSetup,
+};
+
+/// Return capabilities for a given DID
+#[utoipa::path(
+    get,
+    path = "/api/v0/capabilities",
+    security(
+        ("ucan_bearer" = []),
+    ),
+    responses(
+        (status = 200, description = "Found account", body = UcansResponse),
+        (status = 400, description = "Invalid request", body = AppError),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Not found"),
+    )
+)]
+pub async fn get_capabilities<S: ServerSetup>(
+    State(state): State<AppState<S>>,
+    authority: Authority,
+) -> AppResult<(StatusCode, Json<UcansResponse>)> {
+    let Did(audience_needle) = authority.get_capability(IndexingAbility::Find)?;
+
+    let conn = &mut db::connect(&state.db_pool).await?;
+    conn.transaction(|conn| {
+        async move {
+            let ucans = find_ucans_for_audience(audience_needle, conn)
+                .await
+                .map_err(|e| AppError::new(StatusCode::INTERNAL_SERVER_ERROR, Some(e)))?;
+
+            Ok((StatusCode::OK, Json(UcansResponse { ucans })))
+        }
+        .scope_boxed()
+    })
+    .await
+}

--- a/fission-server/src/routes/capability_indexing.rs
+++ b/fission-server/src/routes/capability_indexing.rs
@@ -36,7 +36,7 @@ pub async fn get_capabilities<S: ServerSetup>(
     State(state): State<AppState<S>>,
     authority: Authority,
 ) -> AppResult<(StatusCode, Json<UcansResponse>)> {
-    let Did(audience_needle) = authority.get_capability(IndexingAbility::Find)?;
+    let Did(audience_needle) = authority.get_capability(IndexingAbility::Fetch)?;
 
     let conn = &mut db::connect(&state.db_pool).await?;
     conn.transaction(|conn| {

--- a/fission-server/src/routes/mod.rs
+++ b/fission-server/src/routes/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod account;
 pub mod auth;
+pub mod capability_indexing;
 pub mod doh;
 pub mod fallback;
 pub mod health;

--- a/fission-server/src/test_utils/mod.rs
+++ b/fission-server/src/test_utils/mod.rs
@@ -47,6 +47,7 @@ impl<F: Clone + DeserializeOwned> RouteBuilder<F> {
         self
     }
 
+    #[allow(unused)]
     pub(crate) fn with_ucan_proof(mut self, ucan: Ucan) -> Self {
         self.ucan_proof = Some(ucan);
         self

--- a/fission-server/src/test_utils/test_context.rs
+++ b/fission-server/src/test_utils/test_context.rs
@@ -92,6 +92,7 @@ impl TestContext {
         self.app_state.db_pool.get().await.unwrap()
     }
 
+    #[allow(unused)]
     pub(crate) fn ipfs_db(&self) -> &TestIpfsDatabase {
         &self.app_state.ipfs_db
     }

--- a/fission-server/src/test_utils/test_ipfs_database.rs
+++ b/fission-server/src/test_utils/test_ipfs_database.rs
@@ -18,10 +18,12 @@ pub(crate) struct TestIpfsDatabase {
 #[derive(Debug, Default)]
 struct State {
     pinned_cids: HashSet<Cid>,
+    #[allow(unused)]
     blocks: HashMap<Cid, Bytes>,
 }
 
 impl TestIpfsDatabase {
+    #[allow(unused)]
     pub(crate) fn add(&self, mut data: impl Read) -> Result<Cid> {
         let mut bytes = Vec::new();
         data.read_to_end(&mut bytes)?;


### PR DESCRIPTION
Implements the [`GET /api/v0/capabilities` route](https://github.com/fission-codes/fission-server/blob/main/design/api.md#get-apiv0capabilities).

This allows you to get all UCANs that point to the provided DID (provided in the authorization UCAN as the `capability/fetch` capability resource) as the audience.

The UCAN server will do this caching anyways - and it's useful to give access to this data to the user, so e.g. you can log in to another device very easily, in case you're using a device-syncing passkey.

Closes #182 
Closes #183 