### PR TITLE
feat: Serve the server's DID via DNS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1388,14 +1388,14 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "enum-as-inner"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
+checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1566,6 +1566,7 @@ dependencies = [
  "futures-util",
  "headers",
  "hex",
+ "hickory-server",
  "http",
  "http-serde",
  "hyper",
@@ -1612,7 +1613,6 @@ dependencies = [
  "tracing-appender",
  "tracing-opentelemetry 0.18.0",
  "tracing-subscriber",
- "trust-dns-server",
  "ulid",
  "url",
  "utoipa",
@@ -1974,6 +1974,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-proto"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091a6fbccf4860009355e3efc52ff4acf37a63489aad7435372d44ceeb6fbbcf"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.8.5",
+ "ring 0.16.20",
+ "rustls 0.21.8",
+ "rustls-pemfile",
+ "serde",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b8f021164e6a984c9030023544c57789c51760065cd510572fedcfb04164e8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "rand 0.8.5",
+ "resolv-conf",
+ "rustls 0.21.8",
+ "serde",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tracing",
+]
+
+[[package]]
+name = "hickory-server"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fbbb45bc4dcb456445732c705e3cfdc7393b8bcae5c36ecec36b9d76bd67cb5"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "enum-as-inner",
+ "futures-util",
+ "hickory-proto",
+ "hickory-resolver",
+ "rustls 0.21.8",
+ "serde",
+ "thiserror",
+ "time",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hkdf"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2233,17 +2309,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "idna"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
 
 [[package]]
 name = "idna"
@@ -2717,12 +2782,6 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
 ]
-
-[[package]]
-name = "matches"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matchit"
@@ -4042,7 +4101,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.25.2",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -5514,109 +5573,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "trust-dns-client"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c408c32e6a9dbb38037cece35740f2cf23c875d8ca134d33631cec83f74d3fe"
-dependencies = [
- "cfg-if",
- "data-encoding",
- "futures-channel",
- "futures-util",
- "lazy_static",
- "radix_trie",
- "rand 0.8.5",
- "ring 0.16.20",
- "rustls 0.20.9",
- "thiserror",
- "time",
- "tokio",
- "tracing",
- "trust-dns-proto",
- "webpki",
-]
-
-[[package]]
-name = "trust-dns-proto"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f7f83d1e4a0e4358ac54c5c3681e5d7da5efc5a7a632c90bb6d6669ddd9bc26"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna 0.2.3",
- "ipnet",
- "lazy_static",
- "rand 0.8.5",
- "ring 0.16.20",
- "rustls 0.20.9",
- "rustls-pemfile",
- "serde",
- "smallvec",
- "thiserror",
- "tinyvec",
- "tokio",
- "tokio-rustls 0.23.4",
- "tracing",
- "url",
- "webpki",
-]
-
-[[package]]
-name = "trust-dns-resolver"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aff21aa4dcefb0a1afbfac26deb0adc93888c7d295fb63ab273ef276ba2b7cfe"
-dependencies = [
- "cfg-if",
- "futures-util",
- "ipconfig",
- "lazy_static",
- "lru-cache",
- "parking_lot 0.12.1",
- "resolv-conf",
- "rustls 0.20.9",
- "serde",
- "smallvec",
- "thiserror",
- "tokio",
- "tokio-rustls 0.23.4",
- "tracing",
- "trust-dns-proto",
- "webpki-roots 0.22.6",
-]
-
-[[package]]
-name = "trust-dns-server"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99022f9befa6daec2a860be68ac28b1f0d9d7ccf441d8c5a695e35a58d88840d"
-dependencies = [
- "async-trait",
- "bytes",
- "cfg-if",
- "enum-as-inner",
- "futures-executor",
- "futures-util",
- "rustls 0.20.9",
- "serde",
- "thiserror",
- "time",
- "tokio",
- "tokio-rustls 0.23.4",
- "toml 0.5.11",
- "tracing",
- "trust-dns-client",
- "trust-dns-proto",
- "trust-dns-resolver",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5767,7 +5723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
 dependencies = [
  "form_urlencoded",
- "idna 0.4.0",
+ "idna",
  "percent-encoding",
  "serde",
 ]
@@ -5842,7 +5798,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b92f40481c04ff1f4f61f304d61793c7b56ff76ac1469f1beb199b1445b253bd"
 dependencies = [
- "idna 0.4.0",
+ "idna",
  "lazy_static",
  "regex",
  "serde",
@@ -6032,15 +5988,6 @@ checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
 dependencies = [
  "ring 0.17.5",
  "untrusted 0.9.0",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
 ]
 
 [[package]]

--- a/fission-core/Cargo.toml
+++ b/fission-core/Cargo.toml
@@ -11,7 +11,10 @@ edition = "2021"
 rust-version = "1.70"
 documentation = "https://docs.rs/fission-core"
 repository = "https://github.com/fission-codes/fission-server"
-authors = ["Steven Vandevelde <icid.asset@gmail.com>"]
+authors = [
+    "Philipp Krüger <philipp@fission.codes>",
+    "Steven Vandevelde <icid.asset@gmail.com>",
+]
 
 [lib]
 path = "src/lib.rs"

--- a/fission-server/Cargo.toml
+++ b/fission-server/Cargo.toml
@@ -103,7 +103,7 @@ tracing = "0.1"
 tracing-appender = "0.2"
 tracing-opentelemetry = "0.18"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "parking_lot", "registry"] }
-trust-dns-server = { version = "0.22.0", features = ["dns-over-rustls"] }
+hickory-server = { version = "0.24", features = ["dns-over-rustls"] }
 rs-ucan = { workspace = true }
 ulid = { version = "1.0", features = ["serde"] }
 url = { workspace = true }

--- a/fission-server/Cargo.toml
+++ b/fission-server/Cargo.toml
@@ -11,7 +11,11 @@ edition = "2021"
 rust-version = "1.70"
 documentation = "https://docs.rs/fission-server"
 repository = "https://github.com/fission-codes/fission-server"
-authors = ["Steven Vandevelde <icid.asset@gmail.com>", "Blaine Cook <blaine@fission.codes>"]
+authors = [
+    "Philipp Krüger <philipp@fission.codes>",
+    "Steven Vandevelde <icid.asset@gmail.com>",
+    "Blaine Cook <blaine@fission.codes>",
+]
 default-run = "fission-server-app"
 
 [lib]

--- a/fission-server/config/settings.toml
+++ b/fission-server/config/settings.toml
@@ -29,9 +29,15 @@ process_collector_interval = 10
 [otel]
 exporter_otlp_endpoint = "http://localhost:4317"
 
+[dns]
+server_port = 1053
+default_soa = "dns1.fission.systems hostmaster.fission.codes 0 10800 3600 604800 3600"
+origin = "localhost" # used for serving the `_did.<origin>` DNS TXT entry
+users_origin = "localhost" # used for serving the `_did.<username>.<users_origin>` DNS TXT entry
+
 [server]
 environment = "local"
-did_path = "./server.ed25519.pem"
+keypair_path = "./server.ed25519.pem"
 metrics_port = 4000
 port = 3000
 timeout_ms = 30000

--- a/fission-server/config/settings.toml
+++ b/fission-server/config/settings.toml
@@ -32,6 +32,7 @@ exporter_otlp_endpoint = "http://localhost:4317"
 [dns]
 server_port = 1053
 default_soa = "dns1.fission.systems hostmaster.fission.codes 0 10800 3600 604800 3600"
+default_ttl = 1800
 origin = "localhost" # used for serving the `_did.<origin>` DNS TXT entry
 users_origin = "localhost" # used for serving the `_did.<username>.<users_origin>` DNS TXT entry
 

--- a/fission-server/src/app_state.rs
+++ b/fission-server/src/app_state.rs
@@ -29,7 +29,7 @@ pub struct AppState<S: ServerSetup> {
     /// The currently connected websocket peers
     pub ws_peer_map: WsPeerMap,
     /// The server's decentralized identity (signing/private key)
-    pub did: Arc<EdDidKey>,
+    pub server_key: Arc<EdDidKey>,
 }
 
 /// Builder for [`AppState`]
@@ -74,7 +74,7 @@ impl<S: ServerSetup> AppStateBuilder<S> {
             ipfs_db,
             verification_code_sender,
             ws_peer_map: Default::default(),
-            did: Arc::new(did),
+            server_key: Arc::new(did),
         })
     }
 

--- a/fission-server/src/app_state.rs
+++ b/fission-server/src/app_state.rs
@@ -117,7 +117,7 @@ impl<S: ServerSetup> AppStateBuilder<S> {
     }
 
     /// Set the server's keypair
-    pub fn with_did(mut self, server_keypair: EdDidKey) -> Self {
+    pub fn with_server_keypair(mut self, server_keypair: EdDidKey) -> Self {
         self.server_keypair = Some(server_keypair);
         self
     }

--- a/fission-server/src/dns/mod.rs
+++ b/fission-server/src/dns/mod.rs
@@ -3,7 +3,8 @@
 use self::response_handler::Handle;
 use crate::{
     db::Pool,
-    dns::authority::{did_record_set, record_set, DBBackedAuthority, SERIAL},
+    dns::user_dids::{did_record_set, record_set, UserDidsAuthority},
+    settings::Dns,
 };
 use anyhow::{anyhow, Result};
 use bytes::Bytes;
@@ -12,102 +13,164 @@ use tokio::sync::broadcast;
 use trust_dns_server::{
     authority::{Authority, Catalog, ZoneType},
     client::{rr::RrKey, serialize::txt::RDataParser},
-    proto::rr::{RData, Record, RecordType},
+    proto::rr::{rdata, RData, Record, RecordType},
     resolver::{config::NameServerConfigGroup, Name},
-    server::{Request, RequestHandler},
+    server::{Request, RequestHandler, ResponseHandler, ResponseInfo},
     store::{
         forwarder::{ForwardAuthority, ForwardConfig},
         in_memory::InMemoryAuthority,
     },
 };
 
-pub mod authority;
 pub mod response;
 pub mod response_handler;
+pub mod user_dids;
 
-/// Handle a DNS request
-pub async fn handle_request(request: Request, db_pool: Pool, did: String) -> Result<Bytes> {
-    let (tx, mut rx) = broadcast::channel(1);
-    let response_handle = Handle(tx);
-
-    let catalog = setup_catalog(db_pool, did)?;
-
-    catalog.handle_request(&request, response_handle).await;
-
-    tracing::info!("Fulfilled DNS request");
-
-    Ok(rx.recv().await?)
+/// State for serving DNS
+#[derive(Clone)]
+pub struct DnsServer {
+    /// The authority that handles the server's main `_did` DNS TXT record lookups
+    pub server_did_authority: Arc<InMemoryAuthority>,
+    /// The authority that handles all user `_did` DNS TXT record lookups
+    pub user_did_authority: Arc<UserDidsAuthority>,
+    /// The catch-all authority that forwards requests to secondary nameservers
+    pub forwarder: Arc<ForwardAuthority>,
 }
 
-/// Setup the main DNS catalog, which can function as a RequestHandler for DNS requests.
-///
-/// This sets up three DNS resolving things:
-/// - Something that resolves `TXT _did.<thisserver.com>` to return the server's DID
-/// - Something that resolves `TXT _did.<username>.<thisserver.com>` to return user DIDs
-/// - Something that forwards any DNS requests to cloudflare via DNS-over-TLS.
-pub fn setup_catalog(db_pool: Pool, server_did: String) -> Result<Catalog> {
-    let fission_soa = RData::parse(
-        RecordType::SOA,
-        [
-            "dns1.fission.systems",
-            "hostmaster.fission.codes",
-            "2023000701",
-            "10800",
-            "3600",
-            "604800",
-            "3600",
-        ]
-        .into_iter(),
-        None,
-    )
-    .map_err(|e| anyhow!(e))?;
+impl std::fmt::Debug for DnsServer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DnsState")
+            .field("server_did_authority", &"InMemoryAuthority {{ .. }}")
+            .field("user_did_authority", &self.user_did_authority)
+            .field("forwarder", &"ForwardAuthority {{ .. }}")
+            .finish()
+    }
+}
 
-    let origin_name = Name::from_ascii("localhost.").expect("Invalid hardcoded domain name.");
-    let server_did_name =
-        Name::from_ascii("_did.localhost.").expect("Invalid hardcoded domain name.");
-    let did_rset = did_record_set(&server_did_name, server_did);
-    let server_did_authority = InMemoryAuthority::new(
-        server_did_name.clone(),
-        BTreeMap::from([
-            (
-                RrKey::new(server_did_name.clone().into(), RecordType::TXT),
-                did_rset,
-            ),
-            (
-                RrKey::new(server_did_name.clone().into(), RecordType::SOA),
-                record_set(
-                    &server_did_name,
-                    RecordType::SOA,
-                    SERIAL,
-                    Record::from_rdata(server_did_name.clone(), 1209600, fission_soa),
+impl DnsServer {
+    /// Create a DNS server given some settings, a connection to the DB for DID-by-username lookups
+    /// and the server DID to serve under `_did.<origin>`.
+    pub fn new(settings: &Dns, db_pool: Pool, server_did: String) -> Result<Self> {
+        let default_soa = RData::parse(
+            RecordType::SOA,
+            settings.default_soa.split_ascii_whitespace(),
+            None,
+        )?
+        .into_soa()
+        .map_err(|_| anyhow!("Couldn't parse SOA: {}", settings.default_soa))?;
+
+        Ok(Self {
+            server_did_authority: Arc::new(Self::setup_server_did_authority(
+                settings,
+                server_did,
+                default_soa.clone(),
+            )?),
+            user_did_authority: Arc::new(Self::setup_user_did_authority(
+                settings,
+                db_pool,
+                default_soa,
+            )?),
+            forwarder: Arc::new(Self::setup_forwarder()?),
+        })
+    }
+
+    /// Handle a DNS request
+    pub async fn answer_request(&self, request: Request) -> Result<Bytes> {
+        tracing::info!(?request, "Got DNS request");
+
+        let (tx, mut rx) = broadcast::channel(1);
+        let response_handle = Handle(tx);
+
+        self.handle_request(&request, response_handle).await;
+
+        tracing::debug!("Done handling request, trying to resolve response");
+        Ok(rx.recv().await?)
+    }
+
+    fn setup_server_did_authority(
+        settings: &Dns,
+        server_did: String,
+        default_soa: rdata::SOA,
+    ) -> Result<InMemoryAuthority> {
+        let server_origin = Name::parse(&settings.origin, Some(&Name::root()))?;
+        let server_did_name = Name::parse("_did", Some(&server_origin))?;
+        let serial = default_soa.serial();
+        let did_rset = did_record_set(&server_did_name, server_did, serial);
+        let server_did_authority = InMemoryAuthority::new(
+            server_did_name.clone(),
+            BTreeMap::from([
+                (
+                    RrKey::new(server_did_name.clone().into(), RecordType::TXT),
+                    did_rset,
                 ),
-            ),
-        ]),
-        ZoneType::Primary,
-        false,
-    )
-    .map_err(|e| anyhow!(e))?;
-
-    let db_authority = DBBackedAuthority::new(db_pool, origin_name.into());
-
-    let config = ForwardConfig {
-        name_servers: NameServerConfigGroup::cloudflare_tls(),
-        options: None,
-    };
-
-    let forwarder = ForwardAuthority::try_from_config(Name::root(), ZoneType::Forward, &config)
+                (
+                    RrKey::new(server_did_name.clone().into(), RecordType::SOA),
+                    record_set(
+                        &server_did_name,
+                        RecordType::SOA,
+                        serial,
+                        Record::from_rdata(
+                            server_did_name.clone(),
+                            1209600,
+                            RData::SOA(default_soa),
+                        ),
+                    ),
+                ),
+            ]),
+            ZoneType::Primary,
+            false,
+        )
         .map_err(|e| anyhow!(e))?;
 
-    let mut catalog = Catalog::new();
-    catalog.upsert(
-        db_authority.origin().clone(),
-        Box::new(Arc::new(db_authority)),
-    );
-    catalog.upsert(
-        server_did_authority.origin().clone(),
-        Box::new(Arc::new(server_did_authority)),
-    );
-    catalog.upsert(Name::root().into(), Box::new(Arc::new(forwarder)));
+        Ok(server_did_authority)
+    }
 
-    Ok(catalog)
+    fn setup_user_did_authority(
+        settings: &Dns,
+        db_pool: Pool,
+        default_soa: rdata::SOA,
+    ) -> Result<UserDidsAuthority> {
+        let origin_name = Name::parse(&settings.origin, Some(&Name::root()))?;
+        Ok(UserDidsAuthority::new(
+            db_pool,
+            origin_name.into(),
+            default_soa,
+        ))
+    }
+
+    fn setup_forwarder() -> Result<ForwardAuthority> {
+        let config = ForwardConfig {
+            name_servers: NameServerConfigGroup::cloudflare_tls(),
+            options: None,
+        };
+
+        let forwarder = ForwardAuthority::try_from_config(Name::root(), ZoneType::Forward, &config)
+            .map_err(|e| anyhow!(e))?;
+
+        Ok(forwarder)
+    }
+}
+
+#[async_trait::async_trait]
+impl RequestHandler for DnsServer {
+    async fn handle_request<R: ResponseHandler>(
+        &self,
+        request: &Request,
+        response_handle: R,
+    ) -> ResponseInfo {
+        // A catalog is very light-weight. Just a hashmap.
+        // Shouldn't be a big cost to initialize for requests.
+        let mut catalog = Catalog::new();
+        catalog.upsert(
+            self.user_did_authority.origin().clone(),
+            Box::new(Arc::clone(&self.user_did_authority)),
+        );
+        catalog.upsert(
+            self.server_did_authority.origin().clone(),
+            Box::new(Arc::clone(&self.server_did_authority)),
+        );
+        catalog.upsert(Name::root().into(), Box::new(Arc::clone(&self.forwarder)));
+
+        catalog.handle_request(request, response_handle).await
+    }
 }

--- a/fission-server/src/dns/mod.rs
+++ b/fission-server/src/dns/mod.rs
@@ -8,12 +8,12 @@ use crate::{
 };
 use anyhow::{anyhow, Result};
 use bytes::Bytes;
-use std::{collections::BTreeMap, sync::Arc};
-use tokio::sync::broadcast;
-use trust_dns_server::{
+use hickory_server::{
     authority::{Authority, Catalog, ZoneType},
-    client::{rr::RrKey, serialize::txt::RDataParser},
-    proto::rr::{rdata, RData, Record, RecordType},
+    proto::{
+        rr::{rdata, RData, Record, RecordType, RrKey},
+        serialize::txt::RDataParser,
+    },
     resolver::{config::NameServerConfigGroup, Name},
     server::{Request, RequestHandler, ResponseHandler, ResponseInfo},
     store::{
@@ -21,6 +21,8 @@ use trust_dns_server::{
         in_memory::InMemoryAuthority,
     },
 };
+use std::{collections::BTreeMap, sync::Arc};
+use tokio::sync::broadcast;
 
 pub mod response;
 pub mod response_handler;

--- a/fission-server/src/dns/mod.rs
+++ b/fission-server/src/dns/mod.rs
@@ -95,7 +95,7 @@ impl DnsServer {
         let server_origin = Name::parse(&settings.origin, Some(&Name::root()))?;
         let server_did_name = Name::parse("_did", Some(&server_origin))?;
         let serial = default_soa.serial();
-        let did_rset = did_record_set(&server_did_name, server_did, serial);
+        let did_rset = did_record_set(&server_did_name, server_did, settings.default_ttl, serial);
         let server_did_authority = InMemoryAuthority::new(
             server_did_name.clone(),
             BTreeMap::from([
@@ -135,6 +135,7 @@ impl DnsServer {
             db_pool,
             origin_name.into(),
             default_soa,
+            settings.default_ttl,
         ))
     }
 

--- a/fission-server/src/dns/mod.rs
+++ b/fission-server/src/dns/mod.rs
@@ -1,27 +1,101 @@
 //! DNS
 
-use anyhow::Result;
-use bytes::Bytes;
-use tokio::sync::broadcast;
-use trust_dns_server::server::{Request, RequestHandler};
-
 use self::response_handler::Handle;
-use crate::db::Pool;
+use crate::{
+    db::Pool,
+    dns::authority::{did_record_set, record_set, DBBackedAuthority, SERIAL},
+};
+use anyhow::{anyhow, Result};
+use bytes::Bytes;
+use std::{collections::BTreeMap, sync::Arc};
+use tokio::sync::broadcast;
+use trust_dns_server::{
+    authority::{Authority, Catalog, ZoneType},
+    client::{rr::RrKey, serialize::txt::RDataParser},
+    proto::rr::{RData, Record, RecordType},
+    resolver::{config::NameServerConfigGroup, Name},
+    server::{Request, RequestHandler},
+    store::{
+        forwarder::{ForwardAuthority, ForwardConfig},
+        in_memory::InMemoryAuthority,
+    },
+};
 
 pub mod authority;
 pub mod response;
 pub mod response_handler;
 
-pub use self::{authority::DBBackedAuthority, response::Response};
-
 /// Handle a DNS request
-pub async fn handle_request(request: Request, db_pool: Pool) -> Result<Bytes> {
+pub async fn handle_request(request: Request, db_pool: Pool, did: String) -> Result<Bytes> {
     let (tx, mut rx) = broadcast::channel(1);
     let response_handle = Handle(tx);
 
-    DBBackedAuthority::new(db_pool)
-        .handle_request(&request, response_handle)
-        .await;
+    let fission_soa = RData::parse(
+        RecordType::SOA,
+        [
+            "dns1.fission.systems",
+            "hostmaster.fission.codes",
+            "2023000701",
+            "10800",
+            "3600",
+            "604800",
+            "3600",
+        ]
+        .into_iter(),
+        None,
+    )
+    .map_err(|e| anyhow!(e))?;
 
-    rx.recv().await.map_err(|err| err.into())
+    let origin_name = Name::from_ascii("localhost.").expect("Invalid hardcoded domain name.");
+    let server_did_name =
+        Name::from_ascii("_did.localhost.").expect("Invalid hardcoded domain name.");
+    let did_rset = did_record_set(&server_did_name, did);
+    let server_did_authority = InMemoryAuthority::new(
+        server_did_name.clone(),
+        BTreeMap::from([
+            (
+                RrKey::new(server_did_name.into(), RecordType::TXT),
+                did_rset,
+            ),
+            (
+                RrKey::new(origin_name.clone().into(), RecordType::SOA),
+                record_set(
+                    &origin_name,
+                    RecordType::SOA,
+                    SERIAL,
+                    Record::from_rdata(origin_name.clone(), 1209600, fission_soa),
+                ),
+            ),
+        ]),
+        ZoneType::Primary,
+        false,
+    )
+    .map_err(|e| anyhow!(e))?;
+
+    let db_authority = DBBackedAuthority::new(db_pool, origin_name.clone().into());
+
+    let config = ForwardConfig {
+        name_servers: NameServerConfigGroup::cloudflare_tls(),
+        options: None,
+    };
+
+    let forwarder = ForwardAuthority::try_from_config(Name::root(), ZoneType::Forward, &config)
+        .map_err(|e| anyhow!(e))?;
+
+    let mut catalog = Catalog::new();
+    catalog.upsert(
+        db_authority.origin().clone(),
+        Box::new(Arc::new(db_authority)),
+    );
+    catalog.upsert(
+        server_did_authority.origin().clone(),
+        Box::new(Arc::new(server_did_authority)),
+    );
+    catalog.upsert(Name::root().into(), Box::new(Arc::new(forwarder)));
+
+    catalog.handle_request(&request, response_handle).await;
+
+    tracing::info!("Fulfilled DNS request");
+
+    Ok(rx.recv().await?)
 }

--- a/fission-server/src/dns/response.rs
+++ b/fission-server/src/dns/response.rs
@@ -1,8 +1,8 @@
 //! DNS Response
 
 use anyhow::{bail, ensure, Result};
+use hickory_server::proto;
 use serde::{Deserialize, Serialize};
-use trust_dns_server::proto;
 
 #[derive(Debug, Serialize, Deserialize)]
 /// JSON representation of a DNS response
@@ -130,7 +130,7 @@ impl DohRecordJson {
 
         Ok(Self {
             name: record.name().to_string(),
-            record_type: record.rr_type().into(),
+            record_type: record.record_type().into(),
             ttl: record.ttl(),
             data: data.to_string(),
         })

--- a/fission-server/src/dns/response_handler.rs
+++ b/fission-server/src/dns/response_handler.rs
@@ -2,13 +2,13 @@
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use std::io;
-use tokio::sync::broadcast;
-use trust_dns_server::{
+use hickory_server::{
     authority::MessageResponse,
     proto::{self, serialize::binary::BinEncoder},
     server::{ResponseHandler, ResponseInfo},
 };
+use std::io;
+use tokio::sync::broadcast;
 
 /// A handle to the channel over which the response to a DNS request will be sent
 #[derive(Debug, Clone)]

--- a/fission-server/src/dns/user_dids.rs
+++ b/fission-server/src/dns/user_dids.rs
@@ -6,23 +6,22 @@ use crate::{
 };
 use anyhow::Result;
 use async_trait::async_trait;
-use std::{borrow::Borrow, sync::Arc};
-use trust_dns_server::{
+use hickory_server::{
     authority::{
         AuthLookup, Authority, LookupError, LookupOptions, LookupRecords, MessageRequest,
         UpdateResult, ZoneType,
     },
-    client::rr::LowerName,
     proto::{
         op::ResponseCode,
         rr::{
             rdata::{SOA, TXT},
-            RData, Record, RecordSet, RecordType,
+            LowerName, RData, Record, RecordSet, RecordType,
         },
     },
     resolver::{error::ResolveError, Name},
     server::RequestInfo,
 };
+use std::{borrow::Borrow, sync::Arc};
 
 /// DNS Request Handler for user DIDs of the form `_did.<username>.<server origin>`
 #[derive(Debug)]

--- a/fission-server/src/extract/authority.rs
+++ b/fission-server/src/extract/authority.rs
@@ -97,7 +97,7 @@ where
         parts: &mut Parts,
         state: &AppState<S>,
     ) -> Result<Self, Self::Rejection> {
-        do_extract_authority(parts, state.did.as_str())
+        do_extract_authority(parts, state.server_key.as_str())
             .await
             .map_err(|err| match err {
                 authority::Error::InsufficientCapabilityScope { .. } => {

--- a/fission-server/src/extract/authority.rs
+++ b/fission-server/src/extract/authority.rs
@@ -97,7 +97,7 @@ where
         parts: &mut Parts,
         state: &AppState<S>,
     ) -> Result<Self, Self::Rejection> {
-        do_extract_authority(parts, state.server_key.as_str())
+        do_extract_authority(parts, state.server_keypair.as_str())
             .await
             .map_err(|err| match err {
                 authority::Error::InsufficientCapabilityScope { .. } => {

--- a/fission-server/src/extract/doh.rs
+++ b/fission-server/src/extract/doh.rs
@@ -61,6 +61,8 @@ struct DNSJsonQuery {
     edns_client_subnet: Option<String>,
     #[allow(dead_code)]
     random_padding: Option<String>,
+    #[serde(rename = "rd")]
+    recursion_desired: Option<bool>,
 }
 
 /// A DNS request encoded in the query string
@@ -181,6 +183,8 @@ where
         .set_message_type(proto::op::MessageType::Query)
         .set_op_code(proto::op::OpCode::Query)
         .set_checking_disabled(params.cd.unwrap_or(false))
+        .set_recursion_desired(params.recursion_desired.unwrap_or(true))
+        .set_recursion_available(true)
         .set_authentic_data(params.dnssec_ok.unwrap_or(false));
 
     // This is kind of a hack, but the only way I can find to

--- a/fission-server/src/extract/doh.rs
+++ b/fission-server/src/extract/doh.rs
@@ -12,9 +12,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use bytes::Bytes;
-use http::{header, request::Parts, StatusCode};
-use serde::Deserialize;
-use trust_dns_server::{
+use hickory_server::{
     authority::MessageRequest,
     proto::{
         self,
@@ -22,6 +20,8 @@ use trust_dns_server::{
     },
     server::{Protocol, Request as DNSRequest},
 };
+use http::{header, request::Parts, StatusCode};
+use serde::Deserialize;
 
 /// A DNS packet encoding type
 #[derive(Debug)]

--- a/fission-server/src/main.rs
+++ b/fission-server/src/main.rs
@@ -1,7 +1,6 @@
 //! fission-server
 
 use anyhow::{anyhow, Result};
-
 use axum::{extract::Extension, headers::HeaderName, routing::get, Router};
 use axum_server::Handle;
 use axum_tracing_opentelemetry::{opentelemetry_tracing_layer, response_with_trace_layer};

--- a/fission-server/src/main.rs
+++ b/fission-server/src/main.rs
@@ -276,7 +276,7 @@ async fn serve_dns(
     dns_server: DnsServer,
     token: CancellationToken,
 ) -> Result<()> {
-    let mut server = trust_dns_server::ServerFuture::new(dns_server);
+    let mut server = hickory_server::ServerFuture::new(dns_server);
 
     let ip4_addr = Ipv4Addr::new(127, 0, 0, 1);
     let sock_addr = SocketAddrV4::new(ip4_addr, settings.dns.server_port);

--- a/fission-server/src/main.rs
+++ b/fission-server/src/main.rs
@@ -183,7 +183,7 @@ async fn setup_app_state(settings: &Settings, db_pool: Pool) -> Result<AppState<
         .with_ipfs_peers(settings.ipfs.peers.clone())
         .with_verification_code_sender(EmailVerificationCodeSender::new(settings.mailgun.clone()))
         .with_ipfs_db(IpfsHttpApiDatabase::default())
-        .with_did(server_keypair)
+        .with_server_keypair(server_keypair)
         .with_dns_server(dns_server)
         .finalize()?;
 

--- a/fission-server/src/routes/account.rs
+++ b/fission-server/src/routes/account.rs
@@ -68,7 +68,7 @@ pub async fn create_account<S: ServerSetup>(
                 request.username,
                 verification.email.to_string(),
                 &did,
-                state.did.as_ref(),
+                state.server_key.as_ref(),
             )
             .await?;
 

--- a/fission-server/src/routes/account.rs
+++ b/fission-server/src/routes/account.rs
@@ -68,7 +68,7 @@ pub async fn create_account<S: ServerSetup>(
                 request.username,
                 verification.email.to_string(),
                 &did,
-                state.server_key.as_ref(),
+                state.server_keypair.as_ref(),
             )
             .await?;
 

--- a/fission-server/src/routes/auth.rs
+++ b/fission-server/src/routes/auth.rs
@@ -62,7 +62,7 @@ pub async fn request_token<S: ServerSetup>(
     )
 )]
 pub async fn server_did<S: ServerSetup>(State(state): State<AppState<S>>) -> String {
-    state.did.did()
+    state.server_key.did()
 }
 
 #[cfg(test)]
@@ -202,7 +202,7 @@ mod tests {
 
         let parsed = String::from_utf8(bytes.to_vec())?;
 
-        assert_eq!(parsed, ctx.app_state().did.did());
+        assert_eq!(parsed, ctx.app_state().server_key.did());
 
         Ok(())
     }

--- a/fission-server/src/routes/auth.rs
+++ b/fission-server/src/routes/auth.rs
@@ -62,7 +62,7 @@ pub async fn request_token<S: ServerSetup>(
     )
 )]
 pub async fn server_did<S: ServerSetup>(State(state): State<AppState<S>>) -> String {
-    state.server_key.did()
+    state.server_keypair.did()
 }
 
 #[cfg(test)]
@@ -202,7 +202,7 @@ mod tests {
 
         let parsed = String::from_utf8(bytes.to_vec())?;
 
-        assert_eq!(parsed, ctx.app_state().server_key.did());
+        assert_eq!(parsed, ctx.app_state().server_keypair.did());
 
         Ok(())
     }

--- a/fission-server/src/routes/doh.rs
+++ b/fission-server/src/routes/doh.rs
@@ -20,7 +20,7 @@ pub async fn get<S: ServerSetup>(
     State(state): State<AppState<S>>,
     DNSRequestQuery(request, accept_type): DNSRequestQuery,
 ) -> Response {
-    let response = match dns::handle_request(request, state.db_pool, state.server_key.did()).await {
+    let response = match state.dns_server.answer_request(request).await {
         Ok(response) => response,
         Err(err) => return (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response(),
     };
@@ -51,7 +51,7 @@ pub async fn post<S: ServerSetup>(
     State(state): State<AppState<S>>,
     DNSRequestBody(request): DNSRequestBody,
 ) -> Response {
-    let response = match dns::handle_request(request, state.db_pool, state.server_key.did()).await {
+    let response = match state.dns_server.answer_request(request).await {
         Ok(response) => response,
         Err(err) => return (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response(),
     };

--- a/fission-server/src/routes/doh.rs
+++ b/fission-server/src/routes/doh.rs
@@ -20,7 +20,7 @@ pub async fn get<S: ServerSetup>(
     State(state): State<AppState<S>>,
     DNSRequestQuery(request, accept_type): DNSRequestQuery,
 ) -> Response {
-    let response = match dns::handle_request(request, state.db_pool, state.did.did()).await {
+    let response = match dns::handle_request(request, state.db_pool, state.server_key.did()).await {
         Ok(response) => response,
         Err(err) => return (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response(),
     };
@@ -51,7 +51,7 @@ pub async fn post<S: ServerSetup>(
     State(state): State<AppState<S>>,
     DNSRequestBody(request): DNSRequestBody,
 ) -> Response {
-    let response = match dns::handle_request(request, state.db_pool, state.did.did()).await {
+    let response = match dns::handle_request(request, state.db_pool, state.server_key.did()).await {
         Ok(response) => response,
         Err(err) => return (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response(),
     };

--- a/fission-server/src/routes/doh.rs
+++ b/fission-server/src/routes/doh.rs
@@ -5,8 +5,8 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use hickory_server::proto::{self, serialize::binary::BinDecodable};
 use http::{header::CONTENT_TYPE, StatusCode};
-use trust_dns_server::proto::{self, serialize::binary::BinDecodable};
 
 use crate::{
     app_state::AppState,

--- a/fission-server/src/routes/doh.rs
+++ b/fission-server/src/routes/doh.rs
@@ -20,7 +20,7 @@ pub async fn get<S: ServerSetup>(
     State(state): State<AppState<S>>,
     DNSRequestQuery(request, accept_type): DNSRequestQuery,
 ) -> Response {
-    let response = match dns::handle_request(request, state.db_pool).await {
+    let response = match dns::handle_request(request, state.db_pool, state.did.did()).await {
         Ok(response) => response,
         Err(err) => return (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response(),
     };
@@ -34,7 +34,7 @@ pub async fn get<S: ServerSetup>(
             .into_response(),
         DNSMimeType::Json => {
             let message = proto::op::Message::from_bytes(&response).unwrap();
-            let response = dns::Response::from_message(message).unwrap();
+            let response = dns::response::Response::from_message(message).unwrap();
 
             (
                 StatusCode::OK,
@@ -51,7 +51,7 @@ pub async fn post<S: ServerSetup>(
     State(state): State<AppState<S>>,
     DNSRequestBody(request): DNSRequestBody,
 ) -> Response {
-    let response = match dns::handle_request(request, state.db_pool).await {
+    let response = match dns::handle_request(request, state.db_pool, state.did.did()).await {
         Ok(response) => response,
         Err(err) => return (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response(),
     };

--- a/fission-server/src/settings.rs
+++ b/fission-server/src/settings.rs
@@ -52,6 +52,8 @@ pub struct Dns {
     pub server_port: u16,
     /// SOA record data for any authoritative DNS records
     pub default_soa: String,
+    /// Default time to live for returned DNS records (TXT & SOA)
+    pub default_ttl: u32,
     /// Domain used for serving the `_did.<origin>` DNS TXT entry
     pub origin: String,
     /// Domain used for serving the `_did.<username>.users_origin>` DNS TXT entry

--- a/fission-server/src/settings.rs
+++ b/fission-server/src/settings.rs
@@ -45,6 +45,19 @@ pub struct IPFS {
     pub peers: Vec<String>,
 }
 
+/// DNS server settings
+#[derive(Clone, Debug, Deserialize)]
+pub struct Dns {
+    /// The port to serve a local UDP DNS server at
+    pub server_port: u16,
+    /// SOA record data for any authoritative DNS records
+    pub default_soa: String,
+    /// Domain used for serving the `_did.<origin>` DNS TXT entry
+    pub origin: String,
+    /// Domain used for serving the `_did.<username>.users_origin>` DNS TXT entry
+    pub users_origin: String,
+}
+
 /// Server settings.
 #[derive(Clone, Debug, Deserialize)]
 pub struct Server {
@@ -57,7 +70,7 @@ pub struct Server {
     /// Server timeout in milliseconds.
     pub timeout_ms: u64,
     /// Path to a PEM file containing the server's signing key (used for its DID)
-    pub did_path: String,
+    pub keypair_path: String,
 }
 
 /// Process monitoring settings.
@@ -133,6 +146,8 @@ pub struct Settings {
     pub mailgun: Mailgun,
     /// Healthcheck settings
     pub healthcheck: Healthcheck,
+    /// Local authoritative DNS server settings
+    pub dns: Dns,
 }
 
 impl Settings {

--- a/fission-server/src/test_utils/test_context.rs
+++ b/fission-server/src/test_utils/test_context.rs
@@ -102,7 +102,7 @@ impl TestContext {
     }
 
     pub(crate) fn server_did(&self) -> &EdDidKey {
-        &self.app_state.server_key
+        &self.app_state.server_keypair
     }
 
     pub(crate) fn app_state(&self) -> &AppState<TestSetup> {

--- a/fission-server/src/test_utils/test_context.rs
+++ b/fission-server/src/test_utils/test_context.rs
@@ -10,7 +10,9 @@ use uuid::Uuid;
 use crate::{
     app_state::{AppState, AppStateBuilder},
     db::{self, Conn, MIGRATIONS},
+    dns::DnsServer,
     router::setup_app_router,
+    settings::Dns,
     test_utils::TestVerificationCodeSender,
     traits::ServerSetup,
 };
@@ -64,11 +66,26 @@ impl TestContext {
             .await
             .unwrap();
 
+        let dns_settings = Dns {
+            server_port: 1053,
+            default_soa: "dns1.fission.systems hostmaster.fission.codes 0 10800 3600 604800 3600"
+                .to_string(),
+            default_ttl: 1800,
+            origin: "localhost".to_string(),
+            users_origin: "localhost".to_string(),
+        };
+
+        let keypair = EdDidKey::generate();
+
+        let dns_server = DnsServer::new(&dns_settings, db_pool.clone(), keypair.did())
+            .expect("Could not initialize DNS server");
+
         let builder = AppStateBuilder::default()
             .with_db_pool(db_pool)
             .with_ipfs_db(TestIpfsDatabase::default())
             .with_verification_code_sender(TestVerificationCodeSender::default())
-            .with_did(EdDidKey::generate());
+            .with_server_keypair(keypair)
+            .with_dns_server(dns_server);
 
         let app_state = f(builder).finalize().unwrap();
 

--- a/fission-server/src/test_utils/test_context.rs
+++ b/fission-server/src/test_utils/test_context.rs
@@ -102,7 +102,7 @@ impl TestContext {
     }
 
     pub(crate) fn server_did(&self) -> &EdDidKey {
-        &self.app_state.did
+        &self.app_state.server_key
     }
 
     pub(crate) fn app_state(&self) -> &AppState<TestSetup> {


### PR DESCRIPTION
- Also reworking how DID data is served for users.
- Updated to latest hickory-dns
- Removed volume-related DNS tests (for now)
- Do request forwarding to cloudflare for external requests
- Enables working with the DNS server hosting data under the "localhost" TLD locally.
