### PR TITLE
fix: UCANs with expiration and unbounded exp proofs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1523,7 +1523,10 @@ dependencies = [
  "serde",
  "serde_json",
  "signature 2.1.0",
+ "test-log",
+ "testresult",
  "tracing",
+ "tracing-subscriber",
  "url",
  "utoipa",
  "validator",
@@ -4193,7 +4196,7 @@ dependencies = [
 [[package]]
 name = "rs-ucan"
 version = "0.1.0"
-source = "git+https://github.com/fission-codes/rs-ucan/?branch=quinn-wip-rework#240549b77ec409d57dd0d25790e4a7e85ec47b87"
+source = "git+https://github.com/fission-codes/rs-ucan/?branch=matheus23/tracing-and-fix-capabilities-for#a115731dadbedd0248b47f0677169254800112f1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 test-log = { version = "0.2", default-features = false, features = ["trace"] }
 testresult = "0.3"
-rs-ucan = { git = "https://github.com/fission-codes/rs-ucan/", branch = "quinn-wip-rework", revision = "240549b77ec409d57dd0d25790e4a7e85ec47b87" }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "parking_lot", "registry"] }
+rs-ucan = { git = "https://github.com/fission-codes/rs-ucan/", branch = "matheus23/tracing-and-fix-capabilities-for", revision = "a115731dadbedd0248b47f0677169254800112f1" }
 url = "2.3"
 utoipa = { version = "3.1", features = ["uuid", "axum_extras"] }
 validator = { version = "0.16.0", features = ["derive"] }

--- a/fission-cli/src/lib.rs
+++ b/fission-cli/src/lib.rs
@@ -124,7 +124,11 @@ impl Cli {
                     AccountCommands::Rename(rename) => {
                         let accounts = state.find_accounts(state.find_capabilities()?);
 
-                        let (_info, did, chain) = state.pick_account(accounts, &rename.username)?;
+                        let (_info, did, chain) = state.pick_account(
+                            accounts,
+                            &rename.username,
+                            "Which account do you want to rename?",
+                        )?;
 
                         let new_username = inquire::Text::new("Pick a new username:").prompt()?;
 
@@ -135,7 +139,11 @@ impl Cli {
                     AccountCommands::Delete(delete) => {
                         let accounts = state.find_accounts(state.find_capabilities()?);
 
-                        let (_info, did, chain) = state.pick_account(accounts, &delete.username)?;
+                        let (_info, did, chain) = state.pick_account(
+                            accounts,
+                            &delete.username,
+                            "Which account do you want to delete?",
+                        )?;
 
                         state.delete_account(did, chain)?;
 
@@ -311,6 +319,7 @@ impl<'s> LoadedKeyState<'s> {
         &'u self,
         accounts: Vec<(AccountInfo, Did, Vec<&'u Ucan>)>,
         user_choice: &Option<String>,
+        prompt: &str,
     ) -> Result<(AccountInfo, Did, Vec<&Ucan>)> {
         Ok(match user_choice {
             Some(username) => accounts
@@ -323,10 +332,9 @@ impl<'s> LoadedKeyState<'s> {
                         .iter()
                         .map(|(info, Did(did), _)| info.username.as_ref().unwrap_or(did))
                         .collect();
-                    let account_name =
-                        inquire::Select::new("Which account do you want to rename?", account_names)
-                            .prompt()?
-                            .clone();
+                    let account_name = inquire::Select::new(prompt, account_names)
+                        .prompt()?
+                        .clone();
 
                     accounts
                         .into_iter()
@@ -385,7 +393,7 @@ impl<'s> LoadedKeyState<'s> {
         let Some(chain) =
             find_delegation_chain(&subject_did, &ability, self.key.as_str(), &self.ucans)
         else {
-            bail!("Couldn't find proof for ability {ability} on subject {subject_did}.");
+            bail!("Couldn't find proof for ability {ability} on subject {subject_did}");
         };
 
         let ucan = self.issue_ucan_with(subject_did, ability, &chain)?;

--- a/fission-core/Cargo.toml
+++ b/fission-core/Cargo.toml
@@ -25,6 +25,7 @@ rs-ucan = { workspace = true }
 url = { workspace = true }
 utoipa = { workspace = true }
 validator = { workspace = true }
+tracing-subscriber = { workspace = true }
 erased-serde = "0.3.31"
 linkme = "0.3.15"
 ed25519 = { workspace = true }
@@ -35,3 +36,7 @@ bs58 = "0.5.0"
 zeroize = "1.6.0"
 signature = "2.1.0"
 tracing = "0.1.40"
+
+[dev-dependencies]
+test-log = { workspace = true }
+testresult = { workspace = true }

--- a/fission-core/src/capabilities/fission.rs
+++ b/fission-core/src/capabilities/fission.rs
@@ -24,7 +24,7 @@ pub enum FissionAbility {
     /// `account/manage`, the ability to change e.g. the username or email address
     AccountManage,
     /// `account/noncritical`, any non-destructive abilities like adding data or querying data
-    AccountNonrcitical,
+    AccountNonCritical,
     /// `account/delete`, the abilit to delete an account
     AccountDelete,
 }
@@ -32,7 +32,7 @@ pub enum FissionAbility {
 const ACCOUNT_READ: &str = "account/read";
 const ACCOUNT_CREATE: &str = "account/create";
 const ACCOUNT_MANAGE: &str = "account/manage";
-const ACCOUNT_NONCRITICAL: &str = "account/noncritical";
+const ACCOUNT_NON_CRITICAL: &str = "account/noncritical";
 const ACCOUNT_DELETE: &str = "account/delete";
 
 impl Plugin for FissionPlugin {
@@ -62,7 +62,7 @@ impl Plugin for FissionPlugin {
             ACCOUNT_READ => Some(FissionAbility::AccountRead),
             ACCOUNT_CREATE => Some(FissionAbility::AccountCreate),
             ACCOUNT_MANAGE => Some(FissionAbility::AccountManage),
-            ACCOUNT_NONCRITICAL => Some(FissionAbility::AccountNonrcitical),
+            ACCOUNT_NON_CRITICAL => Some(FissionAbility::AccountNonCritical),
             ACCOUNT_DELETE => Some(FissionAbility::AccountDelete),
             _ => None,
         })
@@ -86,12 +86,12 @@ impl Ability for FissionAbility {
             return false;
         };
 
-        if matches!(other, Self::AccountNonrcitical) {
+        if matches!(other, Self::AccountNonCritical) {
             return match self {
                 Self::AccountRead => true,
                 Self::AccountCreate => true,
                 Self::AccountManage => false,
-                Self::AccountNonrcitical => true,
+                Self::AccountNonCritical => true,
                 Self::AccountDelete => false,
             };
         }
@@ -106,7 +106,7 @@ impl Display for FissionAbility {
             Self::AccountRead => ACCOUNT_READ,
             Self::AccountCreate => ACCOUNT_CREATE,
             Self::AccountManage => ACCOUNT_MANAGE,
-            Self::AccountNonrcitical => ACCOUNT_NONCRITICAL,
+            Self::AccountNonCritical => ACCOUNT_NON_CRITICAL,
             Self::AccountDelete => ACCOUNT_DELETE,
         })
     }

--- a/fission-server/Cargo.toml
+++ b/fission-server/Cargo.toml
@@ -98,7 +98,7 @@ tower-http = { version = "0.4", features = ["catch-panic", "cors", "request-id",
 tracing = "0.1"
 tracing-appender = "0.2"
 tracing-opentelemetry = "0.18"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "parking_lot", "registry"] }
+tracing-subscriber = { workspace = true }
 trust-dns-server = { version = "0.22.0", features = ["dns-over-rustls"] }
 rs-ucan = { workspace = true }
 ulid = { version = "1.0", features = ["serde"] }

--- a/fission-server/src/authority.rs
+++ b/fission-server/src/authority.rs
@@ -101,7 +101,7 @@ impl<F: Clone + DeserializeOwned> Authority<F> {
         caps.first()
             .ok_or_else(|| {
                 anyhow!(
-                "Invalid authorization. Couldn't find proof for {ability_str} as issued from {did}."
+                "Invalid authorization. Couldn't find proof for {ability_str} as issued from {did}"
             )
             })?
             .resource()

--- a/fission-server/src/routes/account.rs
+++ b/fission-server/src/routes/account.rs
@@ -163,7 +163,9 @@ pub async fn patch_username<S: ServerSetup>(
     authority: Authority,
     Path(username): Path<String>,
 ) -> AppResult<(StatusCode, Json<SuccessResponse>)> {
-    let Did(did) = authority.get_capability(FissionAbility::AccountManage)?;
+    let Did(did) = authority
+        .get_capability(FissionAbility::AccountManage)
+        .map_err(|e| AppError::new(StatusCode::FORBIDDEN, Some(e)))?;
 
     let conn = &mut db::connect(&state.db_pool).await?;
 
@@ -195,7 +197,9 @@ pub async fn delete_account<S: ServerSetup>(
     State(state): State<AppState<S>>,
     authority: Authority,
 ) -> AppResult<(StatusCode, Json<Account>)> {
-    let Did(did) = authority.get_capability(FissionAbility::AccountDelete)?;
+    let Did(did) = authority
+        .get_capability(FissionAbility::AccountDelete)
+        .map_err(|e| AppError::new(StatusCode::FORBIDDEN, Some(e)))?;
 
     let conn = &mut db::connect(&state.db_pool).await?;
     conn.transaction(|conn| {

--- a/fission-server/src/routes/capability_indexing.rs
+++ b/fission-server/src/routes/capability_indexing.rs
@@ -36,7 +36,9 @@ pub async fn get_capabilities<S: ServerSetup>(
     State(state): State<AppState<S>>,
     authority: Authority,
 ) -> AppResult<(StatusCode, Json<UcansResponse>)> {
-    let Did(audience_needle) = authority.get_capability(IndexingAbility::Fetch)?;
+    let Did(audience_needle) = authority
+        .get_capability(IndexingAbility::Fetch)
+        .map_err(|e| AppError::new(StatusCode::FORBIDDEN, Some(e)))?;
 
     let conn = &mut db::connect(&state.db_pool).await?;
     conn.transaction(|conn| {


### PR DESCRIPTION
- Depends on an rs-ucan with a bugfix for checking UCAN expiration in delegations correctly: https://github.com/fission-codes/rs-ucan/pull/5
- Fix some CLI prompts to say the right thing
- Map errors for `Authority::get_capability` correctly so they show up as 403 forbidden