### PR TITLE
fix: separator to adhere to ucan bearer token spec

### DIFF
--- a/design/api.md
+++ b/design/api.md
@@ -65,7 +65,7 @@ Registers a full account given an email verification code and delegates the acco
 
 | Field | Type | Comment |
 |-------|------|---------|
-| `code` | `number` | The code from the verification email |
+| `code` | `string` | The code from the verification email |
 | `email` | `string` | |
 | `username` | `string` | |
 | `credentialID` | `string` | Optional. If present, this may be useful for better passkey UX. |

--- a/fission-cli/src/lib.rs
+++ b/fission-cli/src/lib.rs
@@ -551,5 +551,5 @@ fn encode_ucan_header(proofs: &[&Ucan]) -> Result<String> {
         .iter()
         .map(|ucan| Ok(ucan.encode()?))
         .collect::<Result<Vec<_>>>()?
-        .join(" "))
+        .join(", "))
 }

--- a/fission-server/src/extract/authority.rs
+++ b/fission-server/src/extract/authority.rs
@@ -51,8 +51,8 @@ impl Header for UcanHeader {
                 headers::Error::invalid()
             })?;
 
-            for ucan_str in header_str.split_ascii_whitespace() {
-                let ucan = Ucan::from_str(ucan_str).map_err(|e| {
+            for ucan_str in header_str.split(',') {
+                let ucan = Ucan::from_str(ucan_str.trim()).map_err(|e| {
                     tracing::warn!("Got invalid ucan in ucan request header: {e}");
                     headers::Error::invalid()
                 })?;

--- a/fission-server/src/models/email_verification.rs
+++ b/fission-server/src/models/email_verification.rs
@@ -94,7 +94,7 @@ impl EmailVerification {
 fn generate_code() -> String {
     let mut rng = rand::thread_rng();
     // This is maybe way too little entropy. That said, my bank sends me 5 digit codes. 🤷‍♂️
-    let code = rng.gen_range(0..=99999);
+    let code = rng.gen_range(0..=999_999);
     // 0-pad the 6-digit code:
     format!("{code:0>6}")
 }

--- a/fission-server/src/test_utils/route_builder.rs
+++ b/fission-server/src/test_utils/route_builder.rs
@@ -116,7 +116,7 @@ impl<F: Clone + DeserializeOwned> RouteBuilder<F> {
             .drain(..)
             .map(|ucan| ucan.encode())
             .collect::<Result<Vec<String>, _>>()?
-            .join(" ");
+            .join(", ");
         if !proofs_header.is_empty() {
             builder = builder.header("ucan", proofs_header);
         }


### PR DESCRIPTION
Main issue: Fix using a comma as separator between items in the `ucans` header value instead of just whitespace.

Also:
- Fix `design/api.md` docs: The `code` parameter in the email verification request is a `string`, not a `number`
- The verification code should actually be 6 digits, if it's printed like that.