### PR TITLE
feat: Narrow down capability indexing

### DIFF
--- a/design/api.md
+++ b/design/api.md
@@ -144,6 +144,8 @@ In the future this endpoint will be useful for fetching new capabilities from ot
 | `ucans` | `Map<string, string>` | A map of ucans keyed by their canonical CID, giving the DID from the resource in the authorization capabilities. |
 | `revoked` | `Array<string>` | The subset of canonical CIDs of UCANs from `ucans` that have been revoked. |
 
+---
+
 ### POST `/api/v0/revocations`
 
 Revokes a UCAN via a revocation record. The request body format is specified in the UCAN 0.10 specification, see the section on [revocation validation].

--- a/fission-server/src/routes/capability_indexing.rs
+++ b/fission-server/src/routes/capability_indexing.rs
@@ -71,11 +71,12 @@ mod tests {
     async fn index_test_ucan(
         issuer: &EdDidKey,
         audience: &EdDidKey,
+        resource_did: String,
         conn: &mut Conn<'_>,
     ) -> Result<Ucan> {
         let ucan: Ucan = UcanBuilder::default()
             .for_audience(audience)
-            .claiming_capability(Capability::new(Did(issuer.did()), TopAbility, EmptyCaveat))
+            .claiming_capability(Capability::new(Did(resource_did), TopAbility, EmptyCaveat))
             .sign(issuer)?;
 
         index_ucan(&ucan, conn).await?;
@@ -113,7 +114,7 @@ mod tests {
         let device = &EdDidKey::generate();
         let server = ctx.server_did();
 
-        let ucan = index_test_ucan(server, device, conn).await?;
+        let ucan = index_test_ucan(server, device, server.did(), conn).await?;
 
         let (status, response) = fetch_capabilities(device, &ctx).await?;
         assert_eq!(status, StatusCode::OK);
@@ -159,7 +160,7 @@ mod tests {
         let server = ctx.server_did();
 
         // Index a test UCAN from `server` -> `device_other`
-        let ucan_other = index_test_ucan(server, device_other, conn).await?;
+        let ucan_other = index_test_ucan(server, device_other, server.did(), conn).await?;
         // Requesting UCANs delegated to `device` should end up empty
         let (status, response) = fetch_capabilities(device, &ctx).await?;
 
@@ -167,7 +168,7 @@ mod tests {
         assert!(response.ucans.is_empty());
 
         // Index a test UCAN from `server` -> `device` this time
-        let ucan = index_test_ucan(server, device, conn).await?;
+        let ucan = index_test_ucan(server, device, server.did(), conn).await?;
 
         // Requesting UCANs should only return the ones that end in the relevant issuer's DID
         let (_, response) = fetch_capabilities(device, &ctx).await?;
@@ -194,8 +195,8 @@ mod tests {
         let id_two = &EdDidKey::generate();
         let server = ctx.server_did();
 
-        let ucan_one = index_test_ucan(server, id_one, conn).await?;
-        let ucan_two = index_test_ucan(id_one, id_two, conn).await?;
+        let ucan_one = index_test_ucan(server, id_one, server.did(), conn).await?;
+        let ucan_two = index_test_ucan(id_one, id_two, server.did(), conn).await?;
 
         let (status, response) = fetch_capabilities(id_two, &ctx).await?;
 


### PR DESCRIPTION
This introduces some tests to `models/capability_indexing.rs` including a test that would've failed previously.

Previously we returned any UCANs that match up via issuer/audience, irrespective of whether they refer to each other in the `prf` array or whether they talk about the same capability.

Now, we make sure that they're talking about exactly the same resource (in the capability).
This needs to be improved in the future to also check for e.g. the `ucan:<...>` scheme, unless UCAN 1.0 comes out first.

We don't actually make use of the `prf` array, anticipating its deprecation in UCAN 1.0.