### PR TITLE
feat: Support DNS-based usernames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,6 +1575,7 @@ dependencies = [
  "ed25519-dalek 2.1.0",
  "erased-serde",
  "hickory-proto",
+ "idna 0.5.0",
  "libipld",
  "linkme",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ resolver = "2"
 anyhow = { version = "1.0", features = ["backtrace"] }
 axum = { version = "0.6", features = ["headers"] }
 config = "0.13"
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 ed25519 = "2.2.2"
 ed25519-dalek = { version = "2.0.0", features = ["rand_core", "zeroize", "pem"] }
 rand = "0.8"

--- a/fission-cli/src/cli.rs
+++ b/fission-cli/src/cli.rs
@@ -2,7 +2,7 @@
 use crate::{
     logging::{LogAndHandleErrorMiddleware, LoggingCacheManager},
     paths::config_file,
-    responses::{AccountInfo, AccountResponse},
+    responses::AccountAndAuth,
     settings::Settings,
     ucan::{encode_ucan_header, find_delegation_chain},
 };
@@ -11,10 +11,12 @@ use clap::{Parser, Subcommand};
 use ed25519::pkcs8::{spki::der::pem::LineEnding, DecodePrivateKey, EncodePrivateKey};
 use fission_core::{
     capabilities::{did::Did, fission::FissionAbility, indexing::IndexingAbility},
-    common::{AccountCreationRequest, AccountLinkRequest, EmailVerifyRequest, UcansResponse},
+    common::{
+        Account, AccountCreationRequest, AccountLinkRequest, EmailVerifyRequest, UcansResponse,
+    },
     dns,
     ed_did_key::EdDidKey,
-    username::Username,
+    username::{Handle, Username},
 };
 use hickory_proto::rr::RecordType;
 use http_cache_reqwest::{CACacheManager, Cache, CacheMode, HttpCache, HttpCacheOptions};
@@ -46,13 +48,13 @@ pub struct Cli {
 #[derive(Debug, Subcommand)]
 pub enum Commands {
     /// Account and login management commands
-    Account(Account),
+    Account(AccountCmds),
     /// Print file paths used by the application (e.g. the path to config)
     Paths,
 }
 
 #[derive(Debug, Parser)]
-pub struct Account {
+pub struct AccountCmds {
     #[command(subcommand)]
     command: AccountCommands,
 }
@@ -112,21 +114,21 @@ impl Cli {
                         tracing::info!(?account, "Logged into account");
                     }
                     AccountCommands::List => {
-                        let accounts = state.find_accounts(state.find_capabilities()?).await;
-                        if accounts.is_empty() {
+                        let auths = state.find_accounts(state.find_capabilities()?).await;
+                        if auths.is_empty() {
                             println!("You don't have access to any accounts yet. Use \"fission-cli account create\" to create a new one.");
                         } else {
                             println!(
                                 "Here's a list of accounts you have access to from this device:"
                             );
 
-                            for (info, did, _) in accounts {
-                                match &info.username {
+                            for auth in auths {
+                                match &auth.account.username {
                                     Some(username) => {
-                                        println!("{username}");
+                                        println!("{}", username.to_unicode());
                                     }
                                     None => {
-                                        println!("Anonymous account with DID {did}.");
+                                        println!("Anonymous account with DID {}", auth.account.did);
                                     }
                                 }
                             }
@@ -135,28 +137,37 @@ impl Cli {
                     AccountCommands::Rename(rename) => {
                         let accounts = state.find_accounts(state.find_capabilities()?).await;
 
-                        let (_info, did, chain) = state.pick_account(
+                        let auth = state.pick_account(
                             accounts,
                             &rename.username,
                             "Which account do you want to rename?",
                         )?;
 
                         let new_username = inquire::Text::new("Pick a new username:").prompt()?;
+                        let new_username = Username::from_unicode(&new_username)?;
 
-                        state.rename_account(did, chain, new_username).await?;
+                        state
+                            .rename_account(
+                                Did(auth.account.did.to_string()),
+                                &auth.ucans,
+                                new_username,
+                            )
+                            .await?;
 
                         println!("Successfully changed your username.");
                     }
                     AccountCommands::Delete(delete) => {
                         let accounts = state.find_accounts(state.find_capabilities()?).await;
 
-                        let (_info, did, chain) = state.pick_account(
+                        let auth = state.pick_account(
                             accounts,
                             &delete.username,
                             "Which account do you want to delete?",
                         )?;
 
-                        state.delete_account(did, chain).await?;
+                        state
+                            .delete_account(Did(auth.account.did.to_string()), &auth.ucans)
+                            .await?;
 
                         println!("Successfully deleted your account.");
                     }
@@ -262,7 +273,7 @@ impl<'s> CliState<'s> {
         Ok((email, code))
     }
 
-    async fn create_account(&mut self) -> Result<AccountInfo> {
+    async fn create_account(&mut self) -> Result<Account> {
         let (email, code) = self.request_email_verification().await?;
 
         let (ucan, proofs) = self.issue_ucan(self.device_did(), FissionAbility::AccountCreate)?;
@@ -271,7 +282,7 @@ impl<'s> CliState<'s> {
         let username = inquire::Text::new("Choose a username:").prompt()?;
         let username = Username::from_unicode(&username)?;
 
-        let response: AccountResponse = self
+        let response: AccountAndAuth = self
             .server_request(Method::POST, "/api/v0/account")?
             .bearer_auth(ucan.encode()?)
             .header("ucan", encode_ucan_header(&proofs)?)
@@ -291,7 +302,7 @@ impl<'s> CliState<'s> {
         Ok(response.account)
     }
 
-    async fn link_account(&mut self) -> Result<AccountInfo> {
+    async fn link_account(&mut self) -> Result<Account> {
         let username = inquire::Text::new("What's your username?").prompt()?;
 
         let account_did = doh_request(
@@ -308,7 +319,7 @@ impl<'s> CliState<'s> {
 
         let (ucan, proofs) = self.issue_ucan(self.device_did(), FissionAbility::AccountLink)?;
 
-        let response: AccountResponse = self
+        let response: AccountAndAuth = self
             .server_request(Method::POST, &format!("/api/v0/account/{account_did}/link"))?
             .bearer_auth(ucan.encode()?)
             .header("ucan", encode_ucan_header(&proofs)?)
@@ -326,7 +337,7 @@ impl<'s> CliState<'s> {
         Ok(response.account)
     }
 
-    fn find_capabilities(&'s self) -> Result<Vec<(Did, Vec<&'s Ucan>)>> {
+    fn find_capabilities(&self) -> Result<Vec<(Did, Vec<Ucan>)>> {
         let mut caps = Vec::new();
 
         tracing::info!(
@@ -369,11 +380,8 @@ impl<'s> CliState<'s> {
         Ok(caps)
     }
 
-    async fn find_accounts<'u>(
-        &self,
-        caps: Vec<(Did, Vec<&'u Ucan>)>,
-    ) -> Vec<(AccountInfo, Did, Vec<&'u Ucan>)> {
-        let mut accounts = Vec::new();
+    async fn find_accounts(&self, caps: Vec<(Did, Vec<Ucan>)>) -> Vec<AccountAndAuth> {
+        let mut auths = Vec::new();
         for (did, chain) in caps {
             tracing::info!(%did, "Checking if given capability is a valid account");
 
@@ -381,57 +389,68 @@ impl<'s> CliState<'s> {
                 let ucan =
                     self.issue_ucan_with(did.clone(), FissionAbility::AccountRead, &chain)?;
 
-                let response = self
+                let account: Account = self
                     .server_request(Method::GET, &format!("/api/v0/account/{did}"))?
                     .bearer_auth(ucan.encode()?)
                     .header("ucan", encode_ucan_header(&chain)?)
                     .send()
+                    .await?
+                    .json()
                     .await?;
 
-                let account_info: AccountInfo = response.json().await?;
-                tracing::info!(?account_info.username, "Found user");
-                Ok::<_, anyhow::Error>(account_info)
+                tracing::info!(?account.username, "Found user");
+
+                Ok::<_, anyhow::Error>(AccountAndAuth {
+                    account,
+                    ucans: chain,
+                })
             };
 
             match resolve_account.await {
-                Ok(info) => accounts.push((info, did, chain)),
+                Ok(auth) => auths.push(auth),
                 Err(e) => {
                     tracing::debug!(%e, "Error filtered during find_accounts");
                 }
             };
         }
-        accounts
+        auths
     }
 
-    fn pick_account<'u>(
-        &'u self,
-        accounts: Vec<(AccountInfo, Did, Vec<&'u Ucan>)>,
+    fn pick_account(
+        &self,
+        accounts: Vec<AccountAndAuth>,
         user_choice: &Option<String>,
         prompt: &str,
-    ) -> Result<(AccountInfo, Did, Vec<&Ucan>)> {
+    ) -> Result<AccountAndAuth> {
         Ok(match user_choice {
             Some(username) => accounts
                 .into_iter()
-                .find(|(info, _, _)| info.username.as_ref() == Some(username))
+                .find(|auth| auth.account.username.as_ref().map(Handle::as_str) == Some(username))
                 .ok_or_else(|| anyhow!("Couldn't find access to an account with this username."))?,
             None => {
                 if accounts.len() > 1 {
                     let account_names = accounts
                         .iter()
-                        .map(|(info, Did(did), _)| info.username.as_ref().unwrap_or(did))
+                        .map(|auth| {
+                            auth.account
+                                .username
+                                .as_ref()
+                                .map_or(auth.account.did.to_string(), |handle| handle.to_unicode())
+                        })
                         .collect();
-                    let account_name = inquire::Select::new(prompt, account_names)
-                        .prompt()?
-                        .clone();
+
+                    let account_name = inquire::Select::new(prompt, account_names).prompt()?;
 
                     accounts
                         .into_iter()
-                        .find(|(info, Did(did), _)| {
-                            info.username.as_ref().unwrap_or(did) == &account_name
+                        .find(|auth| {
+                            auth.account
+                                .username
+                                .as_ref()
+                                .map_or(auth.account.did.to_string(), |handle| handle.to_unicode())
+                                == account_name
                         })
-                        .ok_or_else(|| {
-                            anyhow!("Something went wrong. Couldn't selected account.")
-                        })?
+                        .ok_or_else(|| anyhow!("Something went wrong. Couldn't select account."))?
                 } else {
                     accounts.into_iter().next().ok_or_else(|| {
                         anyhow!("Please provide the username in the command argument.")
@@ -441,32 +460,27 @@ impl<'s> CliState<'s> {
         })
     }
 
-    async fn rename_account(
-        &self,
-        did: Did,
-        chain: Vec<&Ucan>,
-        new_username: String,
-    ) -> Result<()> {
-        let ucan = self.issue_ucan_with(did, FissionAbility::AccountManage, &chain)?;
+    async fn rename_account(&self, did: Did, chain: &[Ucan], new_username: Username) -> Result<()> {
+        let ucan = self.issue_ucan_with(did, FissionAbility::AccountManage, chain)?;
 
         self.server_request(
             Method::PATCH,
             &format!("/api/v0/account/username/{new_username}"),
         )?
         .bearer_auth(ucan.encode()?)
-        .header("ucan", encode_ucan_header(&chain)?)
+        .header("ucan", encode_ucan_header(chain)?)
         .send()
         .await?;
 
         Ok(())
     }
 
-    async fn delete_account(&self, did: Did, chain: Vec<&Ucan>) -> Result<()> {
-        let ucan = self.issue_ucan_with(did, FissionAbility::AccountDelete, &chain)?;
+    async fn delete_account(&self, did: Did, chain: &[Ucan]) -> Result<()> {
+        let ucan = self.issue_ucan_with(did, FissionAbility::AccountDelete, chain)?;
 
         self.server_request(Method::DELETE, "/api/v0/account")?
             .bearer_auth(ucan.encode()?)
-            .header("ucan", encode_ucan_header(&chain)?)
+            .header("ucan", encode_ucan_header(chain)?)
             .send()
             .await?;
 
@@ -483,7 +497,7 @@ impl<'s> CliState<'s> {
         &self,
         subject_did: Did,
         ability: impl Ability + Debug,
-    ) -> Result<(Ucan, Vec<&Ucan>)> {
+    ) -> Result<(Ucan, Vec<Ucan>)> {
         let Some(chain) =
             find_delegation_chain(&subject_did, &ability, self.key.did_as_str(), &self.ucans)
         else {
@@ -499,7 +513,7 @@ impl<'s> CliState<'s> {
         &self,
         subject_did: Did,
         ability: impl Ability,
-        chain: &[&Ucan],
+        chain: &[Ucan],
     ) -> Result<Ucan> {
         let mut builder = UcanBuilder::default()
             .for_audience(&self.server_did)

--- a/fission-cli/src/cli.rs
+++ b/fission-cli/src/cli.rs
@@ -14,6 +14,7 @@ use fission_core::{
     common::{AccountCreationRequest, AccountLinkRequest, EmailVerifyRequest, UcansResponse},
     dns,
     ed_did_key::EdDidKey,
+    username::Username,
 };
 use hickory_proto::rr::RecordType;
 use http_cache_reqwest::{CACacheManager, Cache, CacheMode, HttpCache, HttpCacheOptions};
@@ -268,6 +269,7 @@ impl<'s> CliState<'s> {
 
         // TODO Check for availablility. Allow retries.
         let username = inquire::Text::new("Choose a username:").prompt()?;
+        let username = Username::from_unicode(&username)?;
 
         let response: AccountResponse = self
             .server_request(Method::POST, "/api/v0/account")?

--- a/fission-cli/src/responses.rs
+++ b/fission-cli/src/responses.rs
@@ -1,17 +1,9 @@
+use fission_core::common::Account;
 use rs_ucan::ucan::Ucan;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct AccountResponse {
-    pub account: AccountInfo,
+pub struct AccountAndAuth {
+    pub account: Account,
     pub ucans: Vec<Ucan>,
-}
-
-/// Information about an account
-#[derive(Deserialize, Serialize, Debug)]
-pub struct AccountInfo {
-    /// username, if associated
-    pub username: Option<String>,
-    /// email, if associated
-    pub email: Option<String>,
 }

--- a/fission-cli/src/ucan.rs
+++ b/fission-cli/src/ucan.rs
@@ -4,12 +4,12 @@ use rs_ucan::{semantics::ability::Ability, ucan::Ucan};
 use std::fmt::Debug;
 
 #[tracing::instrument(skip(ucans))]
-pub(crate) fn find_delegation_chain<'u>(
+pub(crate) fn find_delegation_chain(
     subject_did: &Did,
     ability: &(impl Ability + ?Sized + Debug),
     target_did: &str,
-    ucans: &'u [Ucan],
-) -> Option<Vec<&'u Ucan>> {
+    ucans: &[Ucan],
+) -> Option<Vec<Ucan>> {
     // This kinda fakes it for now
     // Would make a lot more sense in UCAN v1.0
     // We don't really follow the `prf`s
@@ -60,7 +60,7 @@ pub(crate) fn find_delegation_chain<'u>(
 
         current_target = ucan.issuer();
 
-        chain.push(ucan);
+        chain.push(ucan.clone());
 
         if current_target == subject_did.as_ref() {
             tracing::debug!("Finished chain");
@@ -69,7 +69,7 @@ pub(crate) fn find_delegation_chain<'u>(
     }
 }
 
-pub(crate) fn encode_ucan_header(proofs: &[&Ucan]) -> Result<String> {
+pub(crate) fn encode_ucan_header(proofs: &[Ucan]) -> Result<String> {
     Ok(proofs
         .iter()
         .map(|ucan| Ok(ucan.encode()?))

--- a/fission-core/Cargo.toml
+++ b/fission-core/Cargo.toml
@@ -44,6 +44,7 @@ toml = "0.8"
 data-encoding = "2.5.0"
 assert_matches = "1.5.0"
 hickory-proto = { version = "0.24", default-features = false }
+idna = "0.5.0"
 
 [dev-dependencies]
 test-log = { workspace = true }

--- a/fission-core/src/common.rs
+++ b/fission-core/src/common.rs
@@ -1,5 +1,6 @@
 //! Request and response data types that are common and useful between clients of and the fission server
 
+use crate::username::{Handle, Username};
 use rs_ucan::ucan::Ucan;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
@@ -18,7 +19,7 @@ pub struct EmailVerifyRequest {
 #[derive(Deserialize, Serialize, Clone, Debug, ToSchema, Validate)]
 pub struct AccountCreationRequest {
     /// Username associated with the account
-    pub username: String,
+    pub username: Username,
     /// Email address associated with the account
     #[validate(email)]
     pub email: String,
@@ -37,7 +38,7 @@ pub struct AccountLinkRequest {
 #[derive(Deserialize, Serialize, Clone, Debug, ToSchema)]
 pub struct AccountResponse {
     /// username, if associated
-    pub username: Option<String>,
+    pub username: Option<Handle>,
     /// email, if associated
     pub email: Option<String>,
 }

--- a/fission-core/src/common.rs
+++ b/fission-core/src/common.rs
@@ -60,8 +60,10 @@ pub struct SuccessResponse {
 #[derive(Serialize, Deserialize, Debug, ToSchema)]
 pub struct UcansResponse {
     /// Ucans indexed by their canonical CID (base32, sha-256 and raw codec)
+    #[schema(value_type = HashMap<String, String>)]
     pub ucans: BTreeMap<String, Ucan>,
     /// The subset of canonical CIDs of UCANs that are revoked
+    #[schema(value_type = Vec<String>)]
     pub revoked: BTreeSet<String>,
 }
 

--- a/fission-core/src/common.rs
+++ b/fission-core/src/common.rs
@@ -34,15 +34,6 @@ pub struct AccountLinkRequest {
     pub code: String,
 }
 
-/// Information about an account
-#[derive(Deserialize, Serialize, Clone, Debug, ToSchema)]
-pub struct AccountResponse {
-    /// username, if associated
-    pub username: Option<Handle>,
-    /// email, if associated
-    pub email: Option<String>,
-}
-
 /// Information about the DID of an account
 #[derive(Deserialize, Serialize, Clone, Debug, ToSchema)]
 pub struct DidResponse {
@@ -80,4 +71,18 @@ impl UcansResponse {
             }
         })
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+/// Information about an account
+pub struct Account {
+    /// Account DID
+    pub did: String,
+
+    /// Username associated with the account
+    #[schema(value_type = Option<String>)]
+    pub username: Option<Handle>,
+
+    /// Email address associated with the account
+    pub email: Option<String>,
 }

--- a/fission-core/src/lib.rs
+++ b/fission-core/src/lib.rs
@@ -11,3 +11,4 @@ pub mod dns;
 pub mod ed_did_key;
 pub mod revocation;
 pub mod serde_value_source;
+pub mod username;

--- a/fission-core/src/username.rs
+++ b/fission-core/src/username.rs
@@ -1,6 +1,6 @@
 //! Usernames and Handles
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use utoipa::ToSchema;
@@ -61,7 +61,7 @@ impl FromStr for Username {
 impl Username {
     /// Try to turn a unicode username
     pub fn from_unicode(s: &str) -> Result<Self> {
-        let inner = idna::punycode::encode_str(s).ok_or(anyhow!("cannot encode punycode",))?;
+        let inner = idna::domain_to_ascii(s)?;
         let username = Self { inner };
         username.validate()?;
         Ok(username)

--- a/fission-core/src/username.rs
+++ b/fission-core/src/username.rs
@@ -1,0 +1,224 @@
+//! Usernames and Handles
+
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+use utoipa::ToSchema;
+use validator::{Validate, ValidationError, ValidationErrors};
+
+/// A verified username.
+///
+/// This doesn't include the domain portion.
+/// A struct representing that would be `Handle`.
+///
+/// Unicode is represented as punycode in this case.
+///
+/// Usernames have a 63 byte limit (in punycode encoding)
+/// due to inherent limits in the DNS protocol.
+///
+/// The `Display` instance and `from_unicode` function work
+/// with unicode, everything else works with the encoded
+/// punycode variants.
+#[derive(Clone, ToSchema, Serialize, Deserialize, Validate, Eq, PartialEq, PartialOrd, Ord)]
+#[serde(transparent)]
+pub struct Username {
+    #[validate(length(min = 1, max = 63))]
+    #[validate(custom = "valid_domain_encoding")]
+    #[validate(custom = "first_character_restrictions")]
+    inner: String,
+}
+
+impl std::fmt::Debug for Username {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Username").field(&self.inner).finish()
+    }
+}
+
+impl AsRef<str> for Username {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl std::fmt::Display for Username {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.as_str().fmt(f)
+    }
+}
+
+impl FromStr for Username {
+    type Err = ValidationErrors;
+
+    fn from_str(s: &str) -> Result<Self, ValidationErrors> {
+        let username = Self {
+            inner: s.to_string(),
+        };
+        username.validate()?;
+        Ok(username)
+    }
+}
+
+impl Username {
+    /// Try to turn a unicode username
+    pub fn from_unicode(s: &str) -> Result<Self> {
+        let inner = idna::punycode::encode_str(s).ok_or(anyhow!("cannot encode punycode",))?;
+        let username = Self { inner };
+        username.validate()?;
+        Ok(username)
+    }
+
+    /// Get a string reference of this username.
+    /// This will give you the punycode variant.
+    pub fn as_str(&self) -> &str {
+        self.inner.as_str()
+    }
+
+    /// Get this username as a unicode string
+    pub fn to_unicode(&self) -> String {
+        idna::domain_to_unicode(self.as_str()).0
+    }
+}
+
+/// A verified handle.
+///
+/// This is a full username containing the name portion
+/// and any domains (e.g. `matheus23.fission.name`).
+///
+/// It's only deemed valid if <= 220 bytes, to leave space
+/// potential subdomain records needed such as e.g.
+/// `_did.` (`_did.matheus23.fission.name`) and any future ones.
+///
+/// If unicode is needed, use punycode for internationalized
+/// domain names (IDNs).
+///
+/// The length limit is determined in the punycode-encoded variant.
+#[derive(Clone, ToSchema, Serialize, Deserialize, Validate, Eq, PartialEq, PartialOrd, Ord)]
+#[serde(transparent)]
+pub struct Handle {
+    #[validate(length(min = 1, max = 220))]
+    #[validate(custom = "valid_domain_encoding")]
+    inner: String,
+}
+
+impl std::fmt::Debug for Handle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Handle").field(&self.as_str()).finish()
+    }
+}
+
+impl std::fmt::Display for Handle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.as_str().fmt(f)
+    }
+}
+
+impl FromStr for Handle {
+    type Err = ValidationErrors;
+
+    fn from_str(s: &str) -> Result<Self, ValidationErrors> {
+        let handle = Self {
+            inner: s.to_string(),
+        };
+        handle.validate()?;
+        Ok(handle)
+    }
+}
+
+impl Handle {
+    /// Return a handle as a string reference in punycode format
+    pub fn as_str(&self) -> &str {
+        self.inner.as_str()
+    }
+
+    /// Construct a handle from a username & domain
+    pub fn new(username: &str, domain: &str) -> Result<Self> {
+        Ok(Self::from_str(&format!("{username}.{domain}"))?)
+    }
+
+    /// Get this handle as a unicode string
+    pub fn to_unicode(&self) -> String {
+        idna::domain_to_unicode(self.as_str()).0
+    }
+}
+
+fn valid_domain_encoding(s: &str) -> Result<(), ValidationError> {
+    let err = ValidationError::new("unsuitable for encoding in domain names");
+
+    let (unicode, errs) = idna::domain_to_unicode(s);
+    errs.map_err(|_| err.clone())?;
+
+    let result = idna::domain_to_ascii_strict(&unicode).map_err(|_| err.clone())?;
+
+    if s != result {
+        return Err(err)?;
+    }
+
+    Ok(())
+}
+
+fn first_character_restrictions(s: &str) -> Result<(), ValidationError> {
+    let disallowed_first = ['_', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
+
+    if disallowed_first.iter().any(|needle| s.starts_with(*needle)) {
+        Err(ValidationError::new(
+            "underscores or numbers are disallowed in the first character",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_matches::assert_matches;
+
+    #[test]
+    fn test_username_too_long() {
+        assert_matches!(
+            "x2x4x6x810121416182022242628303234363840424446485052545658606264".parse::<Username>(),
+            Err(_)
+        );
+    }
+
+    #[test]
+    fn test_username_length_limit() {
+        assert_matches!(
+            "xx3x5x7x9111315171921232527293133353739414345474951535557596163".parse::<Username>(),
+            Ok(_)
+        );
+    }
+
+    #[test]
+    fn test_username_invalid_characters() {
+        assert_matches!("this has spaces".parse::<Username>(), Err(_));
+        assert_matches!("Ümlaute".parse::<Username>(), Err(_));
+        assert_matches!("anyUppercase".parse::<Username>(), Err(_));
+    }
+
+    #[test]
+    fn test_username_invalid_first_characters() {
+        assert_matches!("1_starts_with_numbers".parse::<Username>(), Err(_));
+        assert_matches!("_starts_with_underscore".parse::<Username>(), Err(_));
+    }
+
+    #[test]
+    fn test_valid_usernames() {
+        assert_matches!("name".parse::<Username>(), Ok(_));
+        assert_matches!("alice".parse::<Username>(), Ok(_));
+        assert_matches!("bob".parse::<Username>(), Ok(_));
+        assert_matches!("bob22".parse::<Username>(), Ok(_));
+    }
+
+    #[test]
+    fn test_punycode_valid() {
+        assert_matches!(Username::from_unicode("bücher"), Ok(_));
+        assert_matches!(Username::from_unicode("ひらがな"), Ok(_));
+    }
+
+    #[test]
+    fn test_punycode_invvalid() {
+        assert_matches!(Username::from_unicode("Max Müller"), Err(_)); // has a space
+        assert_matches!(Username::from_unicode("_ひらがな"), Err(_)); // starts with underscore
+    }
+}

--- a/fission-server/Cargo.toml
+++ b/fission-server/Cargo.toml
@@ -46,7 +46,7 @@ base64 = "0.21"
 base64-url = "2.0.0"
 bb8 = "0.8.0"
 bytes = "1.4.0"
-chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
+chrono = { workspace = true }
 cid = "0.10.1"
 clap = { version = "4.4.6", features = ["derive"] }
 config = { workspace = true }

--- a/fission-server/src/dns/user_dids.rs
+++ b/fission-server/src/dns/user_dids.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     db::{self, Pool},
-    models::account::Account,
+    models::account::AccountRecord,
 };
 use anyhow::Result;
 use async_trait::async_trait;
@@ -45,7 +45,7 @@ impl UserDidsAuthority {
 
     async fn db_lookup_user_did(&self, username: String) -> Result<String> {
         let conn = &mut db::connect(&self.db_pool).await?;
-        let account = Account::find_by_username(conn, username).await?;
+        let account = AccountRecord::find_by_username(conn, username).await?;
         Ok(account.did)
     }
 }

--- a/fission-server/src/docs.rs
+++ b/fission-server/src/docs.rs
@@ -3,13 +3,13 @@
 use crate::{
     error::AppError,
     extract::authority_addon::UcanAddon,
-    models::account::{Account, AccountAndAuth},
+    models::account::{AccountAndAuth, AccountRecord},
     routes::{account, auth, capability_indexing, health, ping, revocations},
 };
 use fission_core::{
     common::{
-        AccountCreationRequest, AccountLinkRequest, AccountResponse, DidResponse,
-        EmailVerifyRequest, SuccessResponse, UcansResponse,
+        Account, AccountCreationRequest, AccountLinkRequest, DidResponse, EmailVerifyRequest,
+        SuccessResponse, UcansResponse,
     },
     revocation::Revocation,
 };
@@ -35,12 +35,12 @@ use utoipa::OpenApi;
             AppError,
             EmailVerifyRequest,
             SuccessResponse,
+            Account,
             AccountCreationRequest,
             AccountLinkRequest,
-            AccountResponse,
             UcansResponse,
             AccountAndAuth,
-            Account,
+            AccountRecord,
             DidResponse,
             Revocation,
             health::HealthcheckResponse

--- a/fission-server/src/docs.rs
+++ b/fission-server/src/docs.rs
@@ -3,11 +3,14 @@
 use crate::{
     error::AppError,
     extract::authority_addon::UcanAddon,
-    models::account::{Account, RootAccount},
-    routes::{account, auth, health, ping, revocations},
+    models::account::{Account, AccountAndAuth},
+    routes::{account, auth, capability_indexing, health, ping, revocations},
 };
 use fission_core::{
-    common::{AccountCreationRequest, AccountResponse, EmailVerifyRequest, SuccessResponse},
+    common::{
+        AccountCreationRequest, AccountLinkRequest, AccountResponse, DidResponse,
+        EmailVerifyRequest, SuccessResponse, UcansResponse,
+    },
     revocation::Revocation,
 };
 use utoipa::OpenApi;
@@ -21,9 +24,11 @@ use utoipa::OpenApi;
         auth::request_token,
         auth::server_did,
         account::create_account,
+        account::link_account,
         account::get_account,
         account::get_did,
         revocations::post_revocation,
+        capability_indexing::get_capabilities,
     ),
     components(
         schemas(
@@ -31,17 +36,17 @@ use utoipa::OpenApi;
             EmailVerifyRequest,
             SuccessResponse,
             AccountCreationRequest,
+            AccountLinkRequest,
             AccountResponse,
-            RootAccount,
+            UcansResponse,
+            AccountAndAuth,
             Account,
+            DidResponse,
             Revocation,
             health::HealthcheckResponse
         )
     ),
     modifiers(&UcanAddon),
-    tags(
-        (name = "", description = "fission-server service/middleware")
-    )
 )]
 
 /// Tied to OpenAPI documentation.

--- a/fission-server/src/extract/doh.rs
+++ b/fission-server/src/extract/doh.rs
@@ -20,7 +20,7 @@ use hickory_server::{
     },
     server::{Protocol, Request as DNSRequest},
 };
-use http::{header, request::Parts, StatusCode};
+use http::{header, request::Parts, HeaderValue, StatusCode};
 use serde::Deserialize;
 
 /// A DNS packet encoding type
@@ -38,6 +38,16 @@ impl Display for DNSMimeType {
             DNSMimeType::Message => write!(f, "application/dns-message"),
             DNSMimeType::Json => write!(f, "application/dns-json"),
         }
+    }
+}
+
+impl DNSMimeType {
+    /// Turn this mime type to an `Accept` HTTP header value
+    pub fn to_header_value(&self) -> HeaderValue {
+        HeaderValue::from_static(match self {
+            Self::Message => "application/dns-message",
+            Self::Json => "application/dns-json",
+        })
     }
 }
 

--- a/fission-server/src/main.rs
+++ b/fission-server/src/main.rs
@@ -208,6 +208,7 @@ async fn setup_prod_app_state(
     let dns_server = DnsServer::new(&settings.dns, db_pool.clone(), server_keypair.did())?;
 
     let app_state = AppStateBuilder::<ProdSetup>::default()
+        .with_dns_settings(settings.dns.clone())
         .with_db_pool(db_pool)
         .with_ipfs_peers(settings.ipfs.peers.clone())
         .with_verification_code_sender(EmailVerificationCodeSender::new(settings.mailgun.clone()))
@@ -229,6 +230,7 @@ async fn setup_local_app_state(
     let ws_peer_map = Arc::new(WsPeerMap::default());
 
     let app_state = AppStateBuilder::<LocalSetup>::default()
+        .with_dns_settings(settings.dns.clone())
         .with_db_pool(db_pool)
         .with_ipfs_peers(settings.ipfs.peers.clone())
         .with_ws_peer_map(Arc::clone(&ws_peer_map))

--- a/fission-server/src/models/capability_indexing.rs
+++ b/fission-server/src/models/capability_indexing.rs
@@ -45,8 +45,10 @@ pub struct IndexedUcan {
     pub audience: String,
 
     /// UCAN `nbf` field
+    #[schema(value_type = Option<String>)]
     pub not_before: Option<NaiveDateTime>,
     /// UCAN `exp` field
+    #[schema(value_type = Option<String>)]
     pub expires_at: Option<NaiveDateTime>,
 }
 
@@ -66,8 +68,10 @@ pub struct NewIndexedUcan {
     pub audience: String,
 
     /// UCAN `nbf` field
+    #[schema(value_type = Option<String>)]
     pub not_before: Option<NaiveDateTime>,
     /// UCAN `exp` field
+    #[schema(value_type = Option<String>)]
     pub expires_at: Option<NaiveDateTime>,
 }
 

--- a/fission-server/src/models/volume.rs
+++ b/fission-server/src/models/volume.rs
@@ -22,8 +22,10 @@ pub struct Volume {
     pub id: i32,
 
     /// Inserted at timestamp
+    #[schema(value_type = String)]
     pub inserted_at: NaiveDateTime,
     /// Updated at timestamp
+    #[schema(value_type = String)]
     pub updated_at: NaiveDateTime,
 
     /// CID of the Storage Volume

--- a/fission-server/src/routes/auth.rs
+++ b/fission-server/src/routes/auth.rs
@@ -19,10 +19,7 @@ use validator::Validate;
 #[utoipa::path(
     post,
     path = "/api/v0/auth/email/verify",
-    request_body = email_verification::Request,
-    security(
-        ("ucan_bearer" = []),
-    ),
+    request_body = EmailVerifyRequest,
     responses(
         (status = 200, description = "Successfully sent request token", body = SuccessResponse),
         (status = 400, description = "Invalid request"),

--- a/fission-server/src/test_utils/test_context.rs
+++ b/fission-server/src/test_utils/test_context.rs
@@ -69,6 +69,7 @@ impl TestContext {
             .expect("Could not initialize DNS server");
 
         let builder = AppStateBuilder::default()
+            .with_dns_settings(dns_settings)
             .with_db_pool(db_pool)
             .with_ipfs_db(TestIpfsDatabase::default())
             .with_verification_code_sender(TestVerificationCodeSender::default())

--- a/fission-server/src/test_utils/test_context.rs
+++ b/fission-server/src/test_utils/test_context.rs
@@ -12,7 +12,7 @@ use axum::{extract::connect_info::MockConnectInfo, Router};
 use axum_server::service::SendService;
 use diesel::{Connection, PgConnection, RunQueryDsl};
 use diesel_migrations::MigrationHarness;
-use fission_core::ed_did_key::EdDidKey;
+use fission_core::{ed_did_key::EdDidKey, username::Handle};
 use uuid::Uuid;
 
 pub(crate) struct TestContext {
@@ -113,6 +113,10 @@ impl TestContext {
 
     pub(crate) fn app_state(&self) -> &AppState<TestSetup> {
         &self.app_state
+    }
+
+    pub(crate) fn user_handle(&self, username: &str) -> Handle {
+        Handle::new(username, &self.app_state.dns_settings.users_origin).unwrap()
     }
 }
 


### PR DESCRIPTION
- Verify that all usernames are DNS-valid in server requests
- Normalize usernames (lowercase, punycode, etc.) in the CLI, support IDN
- Separate the `AccountRecord` DB record type from an `Account` type that can be returned in requests
- Share the `Account` type across CLI & server
- Add `Cache-Control` headers to DoH responses
- Add `#[schema(value_type = ...)]` annotations to remove errors from the `/swagger-ui` route

## WIP

TODO:
- [ ] Allow setting custom domain handles
- [ ] Verify custom domain handles via DNS(SEC)
- [ ] Fix OpenAPI docs