### PR TITLE
fix: Authenticate the `GET /api/v0/account` endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1422,7 +1422,6 @@ dependencies = [
  "reqwest-tracing",
  "retry-policies",
  "rs-ucan",
- "rsa",
  "serde",
  "serde_json",
  "serde_path_to_error",

--- a/fission-cli/src/cli.rs
+++ b/fission-cli/src/cli.rs
@@ -400,7 +400,7 @@ impl<'s> CliState<'s> {
 
             let resolve_account = async {
                 let ucan =
-                    self.issue_ucan_with(did.clone(), FissionAbility::AccountRead, &chain)?;
+                    self.issue_ucan_with(did.clone(), FissionAbility::AccountInfo, &chain)?;
 
                 let account: Account = self
                     .server_request(Method::GET, "/api/v0/account")?

--- a/fission-cli/src/cli.rs
+++ b/fission-cli/src/cli.rs
@@ -403,7 +403,7 @@ impl<'s> CliState<'s> {
                     self.issue_ucan_with(did.clone(), FissionAbility::AccountRead, &chain)?;
 
                 let account: Account = self
-                    .server_request(Method::GET, &format!("/api/v0/account/{did}"))?
+                    .server_request(Method::GET, "/api/v0/account")?
                     .bearer_auth(ucan.encode()?)
                     .header("ucan", encode_ucan_header(&chain)?)
                     .send()

--- a/fission-core/src/capabilities/fission.rs
+++ b/fission-core/src/capabilities/fission.rs
@@ -17,8 +17,8 @@ rs_ucan::register_plugin!(FISSION, &FissionPlugin);
 /// Abilities for fission accounts
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FissionAbility {
-    /// `account/read`, the ability to read account details like email address/username, etc.
-    AccountRead,
+    /// `account/info`, the ability to read account information like email address/username, etc.
+    AccountInfo,
     /// `account/create`, the ability to create an account
     AccountCreate,
     /// `account/link`, the ability to link the originator to an existing account via email challenge
@@ -31,7 +31,7 @@ pub enum FissionAbility {
     AccountDelete,
 }
 
-const ACCOUNT_READ: &str = "account/read";
+const ACCOUNT_READ: &str = "account/info";
 const ACCOUNT_CREATE: &str = "account/create";
 const ACCOUNT_LINK: &str = "account/link";
 const ACCOUNT_MANAGE: &str = "account/manage";
@@ -62,7 +62,7 @@ impl Plugin for FissionPlugin {
         ability: &str,
     ) -> Result<Option<Self::Ability>, Self::Error> {
         Ok(match ability {
-            ACCOUNT_READ => Some(FissionAbility::AccountRead),
+            ACCOUNT_READ => Some(FissionAbility::AccountInfo),
             ACCOUNT_CREATE => Some(FissionAbility::AccountCreate),
             ACCOUNT_LINK => Some(FissionAbility::AccountLink),
             ACCOUNT_MANAGE => Some(FissionAbility::AccountManage),
@@ -92,7 +92,7 @@ impl Ability for FissionAbility {
 
         if matches!(other, Self::AccountNonCritical) {
             return match self {
-                Self::AccountRead => true,
+                Self::AccountInfo => true,
                 Self::AccountCreate => true,
                 Self::AccountLink => true,
                 Self::AccountManage => false,
@@ -108,7 +108,7 @@ impl Ability for FissionAbility {
 impl Display for FissionAbility {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(match self {
-            Self::AccountRead => ACCOUNT_READ,
+            Self::AccountInfo => ACCOUNT_READ,
             Self::AccountCreate => ACCOUNT_CREATE,
             Self::AccountLink => ACCOUNT_LINK,
             Self::AccountManage => ACCOUNT_MANAGE,
@@ -159,7 +159,7 @@ mod tests {
             .for_audience("did:web:fission.codes")
             .claiming_capability(Capability::new(
                 Did("did:key:sth".to_string()),
-                FissionAbility::AccountRead,
+                FissionAbility::AccountInfo,
                 EmptyCaveat {},
             ))
             .witnessed_by(&root_ucan, None)
@@ -171,7 +171,7 @@ mod tests {
         let capabilities = invocation.capabilities_for(
             alice.did(),
             Did("did:key:sth".to_string()),
-            FissionAbility::AccountRead,
+            FissionAbility::AccountInfo,
             time,
             &did_verifier_map,
             &store,

--- a/fission-server/Cargo.toml
+++ b/fission-server/Cargo.toml
@@ -121,7 +121,6 @@ erased-serde = "0.3.31"
 assert-json-diff = "2.0"
 assert_matches = "1.5.0"
 blake3 = "1.4.1"
-rsa = { version = "0.9" }
 test-log = { workspace = true }
 testresult = { workspace = true }
 uuid = "1.4.1"

--- a/fission-server/src/router.rs
+++ b/fission-server/src/router.rs
@@ -40,7 +40,7 @@ pub fn setup_app_router<S: ServerSetup + 'static>(app_state: AppState<S>) -> Rou
         .route("/auth/email/verify", post(auth::request_token))
         .route("/account", post(account::create_account))
         .route("/account", delete(account::delete_account))
-        .route("/account/:did", get(account::get_account))
+        .route("/account", get(account::get_account))
         .route("/account/:did/link", post(account::link_account))
         .route(
             "/account/username/:username",

--- a/fission-server/src/routes/account.rs
+++ b/fission-server/src/routes/account.rs
@@ -178,7 +178,7 @@ pub async fn get_account<S: ServerSetup>(
     authority: Authority,
 ) -> AppResult<(StatusCode, Json<Account>)> {
     let Did(did) = authority
-        .get_capability(&state, FissionAbility::AccountRead)
+        .get_capability(&state, FissionAbility::AccountInfo)
         .await?;
 
     let conn = &mut db::connect(&state.db_pool).await?;
@@ -1029,7 +1029,7 @@ mod tests {
             issuer: &EdDidKey,
             ctx: &TestContext,
         ) -> Result<(StatusCode, T)> {
-            let invocation = build_acc_invocation(FissionAbility::AccountRead, auth, issuer, ctx)?;
+            let invocation = build_acc_invocation(FissionAbility::AccountInfo, auth, issuer, ctx)?;
 
             RouteBuilder::<DefaultFact>::new(ctx.app(), Method::GET, "/api/v0/account")
                 .with_ucan(invocation)

--- a/fission-server/src/routes/account.rs
+++ b/fission-server/src/routes/account.rs
@@ -161,18 +161,26 @@ pub async fn link_account<S: ServerSetup>(
 /// GET handler to retrieve account details
 #[utoipa::path(
     get,
-    path = "/api/v0/account/{did}",
+    path = "/api/v0/account",
+    security(
+        ("ucan_bearer" = []),
+    ),
     responses(
         (status = 200, description = "Found account", body = Account),
         (status = 400, description = "Invalid request", body = AppError),
         (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden"),
         (status = 404, description = "Not found"),
     )
 )]
 pub async fn get_account<S: ServerSetup>(
     State(state): State<AppState<S>>,
-    Path(did): Path<String>,
+    authority: Authority,
 ) -> AppResult<(StatusCode, Json<Account>)> {
+    let Did(did) = authority
+        .get_capability(&state, FissionAbility::AccountRead)
+        .await?;
+
     let conn = &mut db::connect(&state.db_pool).await?;
 
     let account: AccountRecord = accounts::dsl::accounts
@@ -417,7 +425,6 @@ pub async fn delete_account<S: ServerSetup>(
 mod tests {
     use self::helpers::*;
     use crate::{
-        db::schema::accounts,
         dns::user_dids::did_record_set,
         error::{AppError, ErrorResponse},
         models::account::AccountAndAuth,
@@ -425,8 +432,6 @@ mod tests {
     };
     use anyhow::{bail, Result};
     use assert_matches::assert_matches;
-    use diesel::ExpressionMethods;
-    use diesel_async::RunQueryDsl;
     use fission_core::{
         capabilities::{did::Did, fission::FissionAbility},
         common::{Account, SuccessResponse},
@@ -544,28 +549,14 @@ mod tests {
     #[test_log::test(tokio::test)]
     async fn test_get_account_ok() -> TestResult {
         let ctx = TestContext::new().await;
-        let mut conn = ctx.get_db_conn().await;
 
         let username = "donnie";
         let email = "donnie@example.com";
-        let did = "did:28:06:42:12";
+        let issuer = &EdDidKey::generate();
 
-        diesel::insert_into(accounts::table)
-            .values((
-                accounts::username.eq(username),
-                accounts::email.eq(email),
-                accounts::did.eq(did),
-            ))
-            .execute(&mut conn)
-            .await?;
+        let (_, auth) = create_account(username, email, issuer, &ctx).await?;
 
-        let (status, body) = RouteBuilder::<DefaultFact>::new(
-            ctx.app(),
-            Method::GET,
-            format!("/api/v0/account/{did}"),
-        )
-        .into_json_response::<Account>()
-        .await?;
+        let (status, body) = get_account::<Account>(&auth, issuer, &ctx).await?;
 
         assert_eq!(status, StatusCode::OK);
         assert_eq!(body.username, Some(ctx.user_handle(username)));
@@ -1035,16 +1026,16 @@ mod tests {
 
         pub(super) async fn get_account<T: DeserializeOwned>(
             auth: &AccountAndAuth,
-            _issuer: &EdDidKey,
+            issuer: &EdDidKey,
             ctx: &TestContext,
         ) -> Result<(StatusCode, T)> {
-            RouteBuilder::<DefaultFact>::new(
-                ctx.app(),
-                Method::GET,
-                format!("/api/v0/account/{}", auth.account.did),
-            )
-            .into_json_response::<T>()
-            .await
+            let invocation = build_acc_invocation(FissionAbility::AccountRead, auth, issuer, ctx)?;
+
+            RouteBuilder::<DefaultFact>::new(ctx.app(), Method::GET, "/api/v0/account")
+                .with_ucan(invocation)
+                .with_ucan_proofs(auth.ucans.clone())
+                .into_json_response()
+                .await
         }
     }
 }

--- a/fission-server/src/routes/revocations.rs
+++ b/fission-server/src/routes/revocations.rs
@@ -61,7 +61,7 @@ mod tests {
         let ucan: Ucan = UcanBuilder::default()
             .claiming_capability(Capability::new(
                 Did(issuer.did()),
-                FissionAbility::AccountRead,
+                FissionAbility::AccountInfo,
                 EmptyCaveat,
             ))
             .for_audience("did:web:someone.malicious.com")
@@ -92,7 +92,7 @@ mod tests {
         let ucan: Ucan = UcanBuilder::default()
             .claiming_capability(Capability::new(
                 Did(foreign.did()),
-                FissionAbility::AccountRead,
+                FissionAbility::AccountInfo,
                 EmptyCaveat,
             ))
             .for_audience("did:web:someone")


### PR DESCRIPTION
This was specified to work like that in `design/api.md`, and the CLI actually already adds authentication to the request.
We... just never expected it. That's wrong, so this fixes it.
