### PR TITLE
feat: Implement `GET /api/v0/account/member-number` endpoint

### DIFF
--- a/design/api.md
+++ b/design/api.md
@@ -15,7 +15,8 @@ Today we use a REST API. In the future we may switch to an RPC-based design. Whe
 |--------|------|---------|
 | POST | [`/api/v0/auth/email/verify`](#post-apiv0authemailverify) | Trigger email verification |
 | POST | [`/api/v0/account`](#post-apiv0account) | Create a full account |
-| GET | [`/api/v0/account/:did`](#get-apiv0accountdid) | Get account information by DID |
+| GET | [`/api/v0/account`](#get-apiv0account) | Get latest account information |
+| GET | [`/api/v0/account/member-number`](#get-apiv0accountmembernumber) | Get the account's member number |
 | POST | [`/api/v0/account/:did/link`](#post-apiv0accountdidlink) | Login from another device via email code |
 | PATCH | [`/api/v0/account/username/:username`](#patch-apiv0accountusernameusername) | Change an account's username |
 | PATCH | [`/api/v0/account/handle/:handle`](#patch-apiv0accounthandlehandle) | Change the handle that's associated with an account |
@@ -67,24 +68,25 @@ Registers a full account given an email verification code and delegates the acco
 
 **Request**:
 
-| Field | Type | Comment |
-|-------|------|---------|
-| `code` | `string` | The code from the verification email |
-| `email` | `string` | |
-| `username` | `string` | |
+| Field          | Type     | Comment |
+|----------------|----------|---------|
+| `code`         | `string` | The code from the verification email |
+| `email`        | `string` | |
+| `username`     | `string` | |
 | `credentialID` | `string` | Optional. If present, this may be useful for better passkey UX. |
 
 **Response**:
 
-| Field | Type | Comment |
-|-------|------|---------|
-| `ucans` | `Array<string>` | A set of UCAN delegations that delegate the account's unique DID to the resource DID from the request authorization. |
+| Field     | Type            | Comment |
+|-----------|-----------------|---------|
+| `ucans`   | `Array<string>` | A set of UCAN delegations that delegate the account's unique DID to the resource DID from the request authorization. |
+| `account` | `Account`       | Account information in the same format as the `GET /api/v0/account` response record |
 
 ---
 
-### GET `/api/v0/account/:did`
+### GET `/api/v0/account`
 
-Fetches the latest account information.
+Fetches the latest account information. The account is identified by the DID in the given UCAN's resource.
 
 **Authorization**: UCAN giving access to the ability `account/info` with the account's DID as resource.
 
@@ -92,11 +94,27 @@ Fetches the latest account information.
 
 **Response**:
 
-| Field      | Type     |
-|------------|----------|
-| `email`    | `string` |
-| `did`      | `string` |
-| `username` | `string` |
+| Field      | Type      |
+|------------|-----------|
+| `email`    | `string?` |
+| `did`      | `string`  |
+| `username` | `string?` |
+
+---
+
+### GET `/api/v0/account/member-number`
+
+Fetches the account's member number. The account is identified by the DID in the given UCAN's resource.
+
+**Authorization**: UCAN giving access to the ability `account/info` with the account's DID as resource.
+
+**Request**: *Empty*
+
+**Response**:
+
+| Field          | Type     |
+|----------------|----------|
+| `memberNumber` | `number` |
 
 ---
 

--- a/fission-core/src/common.rs
+++ b/fission-core/src/common.rs
@@ -46,6 +46,14 @@ pub struct SuccessResponse {
     pub success: bool,
 }
 
+/// Response for the member number
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MemberNumberResponse {
+    /// The account's member number
+    pub member_number: i32,
+}
+
 /// Response type containing UCANs
 #[derive(Serialize, Deserialize, Debug, ToSchema)]
 pub struct UcansResponse {

--- a/fission-server/src/docs.rs
+++ b/fission-server/src/docs.rs
@@ -8,8 +8,8 @@ use crate::{
 };
 use fission_core::{
     common::{
-        Account, AccountCreationRequest, AccountLinkRequest, EmailVerifyRequest, SuccessResponse,
-        UcansResponse,
+        Account, AccountCreationRequest, AccountLinkRequest, EmailVerifyRequest,
+        MemberNumberResponse, SuccessResponse, UcansResponse,
     },
     revocation::Revocation,
 };
@@ -25,6 +25,7 @@ use utoipa::OpenApi;
         account::create_account,
         account::link_account,
         account::get_account,
+        account::get_member_number,
         account::patch_username,
         account::patch_handle,
         account::delete_account,
@@ -36,6 +37,7 @@ use utoipa::OpenApi;
             AppError,
             EmailVerifyRequest,
             SuccessResponse,
+            MemberNumberResponse,
             Account,
             AccountCreationRequest,
             AccountLinkRequest,

--- a/fission-server/src/router.rs
+++ b/fission-server/src/router.rs
@@ -41,6 +41,7 @@ pub fn setup_app_router<S: ServerSetup + 'static>(app_state: AppState<S>) -> Rou
         .route("/account", post(account::create_account))
         .route("/account", delete(account::delete_account))
         .route("/account", get(account::get_account))
+        .route("/account/member-number", get(account::get_member_number))
         .route("/account/:did/link", post(account::link_account))
         .route(
             "/account/username/:username",


### PR DESCRIPTION
As a replacement for returning the database ID in `GET /api/v0/account`.
This is easier to deprecate eventually and allowed some separation of concerns in the codebase.