### PR TITLE
chore: Better README & fix `nix run .`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ This repository contains an implementation of the fission webserver, an implemen
 
 ## Overview
 
+- [Server design documentation](./design/README.md)
+- [Server API documentation](./design/api.md)
+- [`fission-server`](./fission-server/README.md): Contains the webserver implementation and two binaries, one for running the webserver, one for generating an openAPI document.
+- [`fission-cli`](./fission-cli/README.md): Contains the CLI implementation, its binary is the CLI.
+- [`fission-core`](./fission-core/README.md): Contains code that can be shared between CLI and server, such as request/response types.
+
 The dependencies between the crates in this workspace look like this:
 
 ```mermaid
@@ -36,12 +42,6 @@ flowchart TD
   fission-server --> fission-core
   fission-cli --> fission-core
 ```
-
-- [Server design documentation](./design/README.md)
-- [Server API documentation](./design/api.md)
-- [`fission-server`](./fission-server/README.md): Contains the webserver implementation and two binaries, one for running the webserver, one for generating an openAPI document.
-- [`fission-cli`](./fission-cli/README.md): Contains the CLI implementation, its binary is the CLI.
-- [`fission-core`](./fission-core/README.md): Contains code that can be shared between CLI and server, such as request/response types.
 
 ## Running the Webserver
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,4 @@
 <div align="center">
-  <a href="https://github.com/fission-codes/fission-server" target="_blank">
-    <img src="https://raw.githubusercontent.com/fission-codes/fission-server/main/assets/a_logo.png" alt="fission-server Logo" width="100"></img>
-  </a>
-
-  <h1 align="center">fission-server</h1>
-
   <p>
     <a href="https://crates.io/crates/fission-server">
       <img src="https://img.shields.io/crates/v/fission-server?label=crates" alt="Crate">

--- a/README.md
+++ b/README.md
@@ -29,7 +29,25 @@
 
 <div align="center"><sub>⚠️ Work in progress ⚠️</sub></div>
 
-For more information see also the individual crate README files.
+# Fission Server (& CLI)
+
+This repository contains an implementation of the fission webserver, an implementation of a CLI that allows interacting with the webserver.
+
+## Overview
+
+The dependencies between the crates in this workspace look like this:
+
+```mermaid
+flowchart TD
+  fission-server --> fission-core
+  fission-cli --> fission-core
+```
+
+- [Server design documentation](./design/README.md)
+- [Server API documentation](./design/api.md)
+- [`fission-server`](./fission-server/README.md): Contains the webserver implementation and two binaries, one for running the webserver, one for generating an openAPI document.
+- [`fission-cli`](./fission-cli/README.md): Contains the CLI implementation, its binary is the CLI.
+- [`fission-core`](./fission-core/README.md): Contains code that can be shared between CLI and server, such as request/response types.
 
 ## Running the Webserver
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,6 @@ $ cargo watch -c -s "cargo run -p fission-server -- -c ./fission-server/config/s
 
 In production, you may want to enable the `--no-colors` flag on the executable.
 
-All CLI flags are also available as environment-variables, so `FISSION_SERVER_NO_COLORS=true` and `FISSION_SERVER_CONFIG_PATH="./prod-settings.toml"` or even values from the `settings.toml` file itself.
+All CLI flags are also available as environment-variables, so `FISSION_SERVER__NO_COLORS=true` and `FISSION_SERVER__CONFIG_PATH="./prod-settings.toml"` or even values from the `settings.toml` file itself. Double underscores are used as a separator between settings keys, because these can contain underscores themselves.
 
-You'll also want to set `server.environment = "prod"` in `settings.toml`, and with that you'll need to provide a valid `mailgun.api_key` (can also be set as the environment variable `FISSION_SERVER_MAILGUN_API_KEY=...`).
+You'll also want to set `server.environment = "prod"` in `settings.toml`, and with that you'll need to provide a valid `mailgun.api_key` (can also be set as the environment variable `FISSION_SERVER__MAILGUN__API_KEY=...`).

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 
 <div align="center"><sub>⚠️ Work in progress ⚠️</sub></div>
 
+For more information see also the individual crate README files.
 
 ## Running the Webserver
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,40 @@
 
 ## Running the Webserver
 
-To start-up the fission server, run:
+### Using nix
 
-```console
-APP__MAILGUN__API_KEY=<your key> cargo watch -c -s "cargo run --features ansi-logs"
+```sh
+nix run . -- --config-path ./fission-server/config/settings.toml
 ```
+
+### Using pre-installed cargo & postgres
+
+```sh
+$ pg_ctl -o '-k /tmp' -D "./.pg" start
+$ cargo run -p fission-server -- --config-path ./fission-server/config/settings.toml
+```
+
+## Development
+
+You can drop into a development shell, if you have nix installed via
+
+```sh
+$ nix develop
+```
+
+from the project root.
+
+
+You can re-build and re-run the webserver on every file change via `cargo watch`:
+
+```sh
+$ cargo watch -c -s "cargo run -p fission-server -- -c ./fission-server/config/settings.toml"
+```
+
+## Production
+
+In production, you may want to enable the `--no-colors` flag on the executable.
+
+All CLI flags are also available as environment-variables, so `FISSION_SERVER_NO_COLORS=true` and `FISSION_SERVER_CONFIG_PATH="./prod-settings.toml"` or even values from the `settings.toml` file itself.
+
+You'll also want to set `server.environment = "prod"` in `settings.toml`, and with that you'll need to provide a valid `mailgun.api_key` (can also be set as the environment variable `FISSION_SERVER_MAILGUN_API_KEY=...`).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 <div align="center">
   <p>
-    <a href="https://crates.io/crates/fission-server">
-      <img src="https://img.shields.io/crates/v/fission-server?label=crates" alt="Crate">
-    </a>
     <a href="https://codecov.io/gh/fission-codes/fission-server">
       <img src="https://codecov.io/gh/fission-codes/fission-server/branch/main/graph/badge.svg?token=SOMETOKEN" alt="Code Coverage"/>
     </a>
@@ -11,9 +8,6 @@
     </a>
     <a href="https://github.com/fission-codes/fission-server/blob/main/LICENSE">
       <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License">
-    </a>
-    <a href="https://docs.rs/fission-server">
-      <img src="https://img.shields.io/static/v1?label=Docs&message=docs.rs&color=blue" alt="Docs">
     </a>
     <a href="https://fission.codes/discord">
       <img src="https://img.shields.io/static/v1?label=Discord&message=join%20us!&color=mediumslateblue" alt="Discord">

--- a/fission-server/Cargo.toml
+++ b/fission-server/Cargo.toml
@@ -16,14 +16,14 @@ authors = [
     "Steven Vandevelde <icid.asset@gmail.com>",
     "Blaine Cook <blaine@fission.codes>",
 ]
-default-run = "fission-server-app"
+default-run = "fission-server"
 
 [lib]
 path = "src/lib.rs"
 doctest = true
 
 [[bin]]
-name = "fission-server-app"
+name = "fission-server"
 path = "src/main.rs"
 doc = false
 

--- a/fission-server/Cargo.toml
+++ b/fission-server/Cargo.toml
@@ -35,7 +35,7 @@ doc = false
 bench = false
 
 [dependencies]
-ansi_term = { version = "0.12", optional = true, default-features = false }
+ansi_term = { version = "0.12", default-features = false }
 anyhow = { workspace = true }
 async-trait = "0.1.72"
 axum = { workspace = true, features = ["headers", "ws"] }
@@ -127,7 +127,6 @@ uuid = "1.4.1"
 wiremock = "0.5"
 
 [features]
-ansi-logs = ["ansi_term"]
 console = ["console-subscriber"]
 default = []
 

--- a/fission-server/README.md
+++ b/fission-server/README.md
@@ -104,10 +104,12 @@ Once executed, just run `tokio-console --retain-for <*>min` to use it and explor
 
 `fission-server` contains a file for [configuration settings](./config/settings.toml),
 loaded by the application when it starts. Configuration can be overridden using
-environment variables that begin with an *FISSION_SERVER* prefix, for example:
+environment variables that begin with an *FISSION_SERVER* prefix. To allow for underscores
+in variable names, use separators with two underscores between *APP* and the name
+of the setting, for example:
 
 ```bash
-export FISSION_SERVER_SERVER_ENVIRONMENT="dev"
+export FISSION_SERVER__SERVER__ENVIRONMENT="dev"
 ```
 
 This export would override this setting in the [default config](./config/settings.toml):

--- a/fission-server/README.md
+++ b/fission-server/README.md
@@ -29,7 +29,7 @@
 
 <div align="center"><sub>:warning: Work in progress :warning:</sub></div>
 
-##
+## Fission Server
 
 ## Outline
 
@@ -63,12 +63,15 @@ documentation is available as a [swagger-ui][swagger]
 at `http://localhost:3000/swagger-ui/`. Read more in
 [Docs and OpenAPI](#docs-and-openapi).
 
-For local development with logs displayed using ANSI terminal colors, we
+For production with logs displayed without ANSI terminal colors, we
 recommend running:
 
 ```console
-cargo run --features ansi-logs
+cargo run -- --no-colors
 ```
+
+You can customize the logs you want to receive via the `RUST_LOG`
+environment variable.
 
 ### Database
 
@@ -83,7 +86,7 @@ More info in the [Diesel guide](https://diesel.rs/guides/getting-started#install
 To better help diagnose and debug your server application, you can run:
 
 ``` console
-RUSTFLAGS="--cfg tokio_unstable" cargo run --features "console ansi-logs"
+RUSTFLAGS="--cfg tokio_unstable" cargo run --features console
 ```
 
 This command uses a compile-time feature-flag, `console`, to give us local
@@ -101,12 +104,10 @@ Once executed, just run `tokio-console --retain-for <*>min` to use it and explor
 
 `fission-server` contains a file for [configuration settings](./config/settings.toml),
 loaded by the application when it starts. Configuration can be overridden using
-environment variables that begin with an *APP* prefix. To allow for underscores
-in variable names, use separators with two underscores between *APP* and the name
-of the setting, for example:
+environment variables that begin with an *FISSION_SERVER* prefix, for example:
 
 ```bash
-export APP__SERVER__ENVIRONMENT="dev"
+export FISSION_SERVER_SERVER_ENVIRONMENT="dev"
 ```
 
 This export would override this setting in the [default config](./config/settings.toml):

--- a/fission-server/src/main.rs
+++ b/fission-server/src/main.rs
@@ -90,8 +90,8 @@ async fn main() -> Result<()> {
     let cli: Cli = Config::builder()
         .add_source(SerdeValueSource::from(Cli::parse()))
         .add_source(
-            Environment::with_prefix("APP")
-                .separator("__")
+            Environment::with_prefix("FISSION_SERVER")
+                .separator("_")
                 .try_parsing(true),
         )
         .build()?

--- a/fission-server/src/main.rs
+++ b/fission-server/src/main.rs
@@ -91,16 +91,23 @@ async fn main() -> Result<()> {
         .add_source(SerdeValueSource::from(Cli::parse()))
         .add_source(
             Environment::with_prefix("FISSION_SERVER")
-                .separator("_")
+                .separator("__")
                 .try_parsing(true),
         )
         .build()?
         .try_deserialize()?;
 
-    let settings = Settings::load(cli.config_path)?;
+    let settings = Settings::load(cli.config_path.clone())?;
 
     let (stdout_writer, _stdout_guard) = tracing_appender::non_blocking(io::stdout());
     setup_tracing(stdout_writer, &settings.otel, !cli.no_colors)?;
+
+    info!(
+        subject = "cli_settings",
+        category = "init",
+        ?cli,
+        "loaded CLI settings"
+    );
 
     info!(
         subject = "app_settings",

--- a/fission-server/src/main.rs
+++ b/fission-server/src/main.rs
@@ -77,7 +77,10 @@ const REQUEST_ID: &str = "request_id";
 struct Cli {
     #[arg(long, short = 'c', help = "Path to the settings.toml")]
     config_path: Option<PathBuf>,
-    #[arg(long, help = "Whether to turn off colors")]
+    #[arg(
+        long,
+        help = "Whether to turn off ansi terminal colors in log messages"
+    )]
     no_colors: bool,
 }
 
@@ -97,7 +100,7 @@ async fn main() -> Result<()> {
     let settings = Settings::load(cli.config_path)?;
 
     let (stdout_writer, _stdout_guard) = tracing_appender::non_blocking(io::stdout());
-    setup_tracing(stdout_writer, &settings.otel, cli.no_colors)?;
+    setup_tracing(stdout_writer, &settings.otel, !cli.no_colors)?;
 
     info!(
         subject = "app_settings",

--- a/fission-server/src/settings.rs
+++ b/fission-server/src/settings.rs
@@ -163,13 +163,12 @@ impl Settings {
             .unwrap_or(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config/settings.toml"));
         // inject environment variables naming them properly on the settings
         // e.g. [database] url="foo"
-        // would be injected with environment variable APP__DATABASE__URL="foo"
-        // use two underscores as defined by the separator below
+        // would be injected with environment variable FISSION_SERVER_DATABASE_URL="foo"
         let s = Config::builder()
             .add_source(File::with_name(&path.as_path().display().to_string()))
             .add_source(
-                Environment::with_prefix("APP")
-                    .separator("__")
+                Environment::with_prefix("FISSION_SERVER")
+                    .separator("_")
                     .try_parsing(true)
                     .list_separator(",")
                     .with_list_parse_key("ipfs.peers"),

--- a/fission-server/src/settings.rs
+++ b/fission-server/src/settings.rs
@@ -164,11 +164,12 @@ impl Settings {
         // inject environment variables naming them properly on the settings
         // e.g. [database] url="foo"
         // would be injected with environment variable FISSION_SERVER_DATABASE_URL="foo"
+        // use two underscores as defined by the separator below
         let s = Config::builder()
             .add_source(File::with_name(&path.as_path().display().to_string()))
             .add_source(
                 Environment::with_prefix("FISSION_SERVER")
-                    .separator("_")
+                    .separator("__")
                     .try_parsing(true)
                     .list_separator(",")
                     .with_list_parse_key("ipfs.peers"),

--- a/flake.nix
+++ b/flake.nix
@@ -143,7 +143,7 @@
         cargoLock = {
           lockFile = ./Cargo.lock;
           outputHashes = {
-            "rs-ucan-0.1.0" = "sha256-bJq5mMk5TLvE9w1dtY1sRCyE2uVfcMFSupsSFTXw9rY=";
+            "rs-ucan-0.1.0" = "sha256-HSxIzqPECJ9KbPYU0aitjxpCf0CSDAv7su1PGxZlpHc=";
           };
         };
         buildInputs = with pkgs;


### PR DESCRIPTION
With this you can run the webserver using `nix run .`, but you'll need to specify the config path (unlike with `cargo run`), so make sure to pass it like this: `nix run . -- -c fission-server/config/settings.toml` or wherever your settings file resides.

This also changed the environment variable prefix used from `APP` to `FISSION_SERVER`, so e.g. you can set the path to the config file like this, too: `FISSION_SERVER__CONFIG_PATH="fission-server/config/settings.toml" nix run .`.