### PR TITLE
feat: Ephemeral DB mode & CLI integration tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -51,7 +51,7 @@ jobs:
           LLVM_PROFILE_FILE: "fission-server-%p-%m.profraw"
           RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
           RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
-        run: cargo test --all-features
+        run: cargo test --all-features --lib --tests
 
       - name: Install grcov
         run: "curl -L https://github.com/mozilla/grcov/releases/download/v0.8.12/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf -"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -51,6 +51,7 @@ jobs:
           LLVM_PROFILE_FILE: "fission-server-%p-%m.profraw"
           RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
           RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
+        # Disable doctest compilation due to https://github.com/rust-lang/rust/issues/95825
         run: cargo test --all-features --lib --tests
 
       - name: Install grcov

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
 dependencies = [
  "getrandom 0.2.11",
  "once_cell",
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -36,7 +36,7 @@ checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
- "version_check",
+ "version_check 0.9.4",
  "zerocopy",
 ]
 
@@ -244,6 +244,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
+dependencies = [
+ "autocfg 1.1.0",
+]
+
+[[package]]
+name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
@@ -263,12 +272,12 @@ dependencies = [
  "headers",
  "http",
  "http-body",
- "hyper",
+ "hyper 0.14.27",
  "itoa",
  "matchit",
  "memchr",
- "mime",
- "percent-encoding",
+ "mime 0.3.17",
+ "percent-encoding 2.3.1",
  "pin-project-lite",
  "rustversion",
  "serde",
@@ -295,7 +304,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
- "mime",
+ "mime 0.3.17",
  "rustversion",
  "tower-layer",
  "tower-service",
@@ -323,7 +332,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
- "hyper",
+ "hyper 0.14.27",
  "tokio",
  "tower-service",
 ]
@@ -372,6 +381,25 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
+dependencies = [
+ "byteorder",
+ "safemem",
+]
+
+[[package]]
+name = "base64"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "base64"
@@ -471,11 +499,32 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+dependencies = [
+ "block-padding",
+ "byte-tools",
+ "byteorder",
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+dependencies = [
+ "byte-tools",
 ]
 
 [[package]]
@@ -505,6 +554,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,7 +577,7 @@ version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "142316461ed3a3dfcba10417317472da5bfd0461e4d276bf7c07b330766d9490"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "either",
  "futures",
  "hex",
@@ -631,10 +686,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "comma"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "common-multipart-rfc7578"
@@ -646,7 +716,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http",
- "mime",
+ "mime 0.3.17",
  "mime_guess",
  "rand 0.8.5",
  "thiserror",
@@ -829,7 +899,7 @@ version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "cfg-if 1.0.0",
  "crossbeam-utils",
  "memoffset",
@@ -876,7 +946,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
@@ -888,7 +958,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "typenum",
 ]
 
@@ -901,7 +971,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "platforms",
  "rustc_version",
@@ -1110,11 +1180,20 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -1192,7 +1271,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -1237,9 +1316,9 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
- "generic-array",
+ "generic-array 0.14.7",
  "group",
  "rand_core 0.6.4",
  "sec1",
@@ -1305,7 +1384,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "768064bd3a0e2bedcba91dc87ace90beea91acc41b6a01a3ca8e9aa8827461bf"
 dependencies = [
- "log",
+ "log 0.4.20",
  "once_cell",
  "serde",
  "serde_json",
@@ -1316,6 +1395,12 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fallible-iterator"
@@ -1368,6 +1453,7 @@ dependencies = [
  "assert_cmd",
  "assert_fs",
  "async-trait",
+ "blake3",
  "clap",
  "config",
  "directories",
@@ -1383,8 +1469,10 @@ dependencies = [
  "once_cell",
  "predicates",
  "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "reqwest",
  "reqwest-middleware",
+ "rexpect",
  "rs-ucan",
  "serde",
  "serde_json",
@@ -1395,7 +1483,8 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
- "url",
+ "url 2.5.0",
+ "websocket",
 ]
 
 [[package]]
@@ -1424,7 +1513,7 @@ dependencies = [
  "toml 0.8.8",
  "tracing",
  "tracing-subscriber",
- "url",
+ "url 2.5.0",
  "utoipa",
  "validator",
  "zeroize",
@@ -1469,7 +1558,7 @@ dependencies = [
  "hickory-server",
  "http",
  "http-serde",
- "hyper",
+ "hyper 0.14.27",
  "ipfs-api",
  "ipfs-api-backend-hyper",
  "libipld",
@@ -1477,7 +1566,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "metrics-util",
- "mime",
+ "mime 0.3.17",
  "num_cpus",
  "once_cell",
  "openssl",
@@ -1503,7 +1592,7 @@ dependencies = [
  "test-log",
  "testresult",
  "thiserror",
- "time",
+ "time 0.3.30",
  "tokio",
  "tokio-util",
  "tonic",
@@ -1514,7 +1603,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "ulid",
- "url",
+ "url 2.5.0",
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",
@@ -1568,8 +1657,14 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
- "percent-encoding",
+ "percent-encoding 2.3.1",
 ]
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
@@ -1683,12 +1778,21 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
- "version_check",
+ "version_check 0.9.4",
  "zeroize",
 ]
 
@@ -1730,7 +1834,7 @@ checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
 dependencies = [
  "aho-corasick",
  "bstr",
- "log",
+ "log 0.4.20",
  "regex-automata 0.4.3",
  "regex-syntax 0.8.2",
 ]
@@ -1824,7 +1928,7 @@ dependencies = [
  "headers-core",
  "http",
  "httpdate",
- "mime",
+ "mime 0.3.17",
  "sha1",
 ]
 
@@ -1881,7 +1985,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tracing",
- "url",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -1924,7 +2028,7 @@ dependencies = [
  "rustls",
  "serde",
  "thiserror",
- "time",
+ "time 0.3.30",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -1937,7 +2041,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1986,7 +2090,7 @@ dependencies = [
  "http-cache-semantics",
  "httpdate",
  "serde",
- "url",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -2004,7 +2108,7 @@ dependencies = [
  "reqwest-middleware",
  "serde",
  "task-local-extensions",
- "url",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -2016,7 +2120,7 @@ dependencies = [
  "http",
  "http-serde",
  "serde",
- "time",
+ "time 0.3.30",
 ]
 
 [[package]]
@@ -2053,7 +2157,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "serde_urlencoded",
- "url",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -2073,6 +2177,25 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.10.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a0652d9a2609a968c14be1a9ea00bf4b1d64e2e1f53a1b51b6fff3a6e829273"
+dependencies = [
+ "base64 0.9.3",
+ "httparse",
+ "language-tags",
+ "log 0.3.9",
+ "mime 0.2.6",
+ "num_cpus",
+ "time 0.1.45",
+ "traitobject",
+ "typeable",
+ "unicase 1.4.2",
+ "url 1.7.2",
+]
 
 [[package]]
 name = "hyper"
@@ -2108,7 +2231,7 @@ dependencies = [
  "common-multipart-rfc7578",
  "futures-core",
  "http",
- "hyper",
+ "hyper 0.14.27",
 ]
 
 [[package]]
@@ -2119,7 +2242,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http",
- "hyper",
+ "hyper 0.14.27",
  "rustls",
  "tokio",
  "tokio-rustls",
@@ -2131,7 +2254,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.27",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -2144,7 +2267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.27",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -2181,6 +2304,17 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
@@ -2213,7 +2347,7 @@ checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
 dependencies = [
  "crossbeam-deque",
  "globset",
- "log",
+ "log 0.4.20",
  "memchr",
  "regex-automata 0.4.3",
  "same-file",
@@ -2227,7 +2361,7 @@ version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "hashbrown 0.12.3",
  "serde",
 ]
@@ -2309,7 +2443,7 @@ dependencies = [
  "bytes",
  "futures",
  "http",
- "hyper",
+ "hyper 0.14.27",
  "hyper-multipart-rfc7578",
  "ipfs-api-prelude",
  "thiserror",
@@ -2415,6 +2549,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "language-tags"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2442,7 +2582,7 @@ dependencies = [
  "libipld-json",
  "libipld-macro",
  "libipld-pb",
- "log",
+ "log 0.4.20",
  "multihash 0.18.1",
  "thiserror",
 ]
@@ -2573,8 +2713,17 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
+dependencies = [
+ "log 0.4.20",
 ]
 
 [[package]]
@@ -2629,6 +2778,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2641,7 +2796,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if 1.0.0",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2665,7 +2820,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -2686,7 +2841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a4964177ddfdab1e3a2b37aec7cf320e14169abb0ed73999f558136409178d5"
 dependencies = [
  "base64 0.21.5",
- "hyper",
+ "hyper 0.14.27",
  "indexmap 1.9.3",
  "ipnet",
  "metrics",
@@ -2773,6 +2928,15 @@ dependencies = [
 
 [[package]]
 name = "mime"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
+dependencies = [
+ "log 0.3.9",
+]
+
+[[package]]
+name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
@@ -2783,8 +2947,8 @@ version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
 dependencies = [
- "mime",
- "unicase",
+ "mime 0.3.17",
+ "unicase 2.7.0",
 ]
 
 [[package]]
@@ -2809,7 +2973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
- "log",
+ "log 0.4.20",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
@@ -2823,14 +2987,14 @@ dependencies = [
  "arrayref",
  "byteorder",
  "data-encoding",
- "log",
+ "log 0.4.20",
  "multibase",
  "multihash 0.17.0",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "serde",
  "static_assertions",
  "unsigned-varint",
- "url",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -2865,7 +3029,7 @@ dependencies = [
  "blake2s_simd",
  "blake3",
  "core2",
- "digest",
+ "digest 0.10.7",
  "multihash-derive",
  "sha2",
  "sha3",
@@ -2894,7 +3058,7 @@ checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
  "lazy_static",
  "libc",
- "log",
+ "log 0.4.20",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -2920,6 +3084,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
 dependencies = [
  "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if 1.0.0",
+ "libc",
 ]
 
 [[package]]
@@ -2980,7 +3155,7 @@ version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-traits",
 ]
 
@@ -2990,7 +3165,7 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-integer",
  "num-traits",
 ]
@@ -3001,7 +3176,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "libm",
 ]
 
@@ -3029,6 +3204,12 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "openssl"
@@ -3176,7 +3357,7 @@ dependencies = [
  "once_cell",
  "opentelemetry_api",
  "ordered-float",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "rand 0.8.5",
  "regex",
  "serde_json",
@@ -3308,6 +3489,12 @@ checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
  "base64ct",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "percent-encoding"
@@ -3568,7 +3755,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -3579,7 +3766,7 @@ checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
  "quote",
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -3675,6 +3862,25 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+dependencies = [
+ "autocfg 0.1.8",
+ "libc",
+ "rand_chacha 0.1.1",
+ "rand_core 0.4.2",
+ "rand_hc 0.1.0",
+ "rand_isaac",
+ "rand_jitter",
+ "rand_os",
+ "rand_pcg",
+ "rand_xorshift",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -3683,7 +3889,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc",
+ "rand_hc 0.2.0",
 ]
 
 [[package]]
@@ -3695,6 +3901,16 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+dependencies = [
+ "autocfg 0.1.8",
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3719,6 +3935,21 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
@@ -3737,11 +3968,73 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
+dependencies = [
+ "libc",
+ "rand_core 0.4.2",
+ "winapi",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+dependencies = [
+ "autocfg 0.1.8",
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3771,6 +4064,15 @@ checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3871,17 +4173,17 @@ dependencies = [
  "h2",
  "http",
  "http-body",
- "hyper",
+ "hyper 0.14.27",
  "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
- "log",
- "mime",
+ "log 0.4.20",
+ "mime 0.3.17",
  "mime_guess",
  "native-tls",
  "once_cell",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "pin-project-lite",
  "rustls",
  "rustls-pemfile",
@@ -3893,7 +4195,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls",
  "tower-service",
- "url",
+ "url 2.5.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -3928,7 +4230,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.11",
  "http",
- "hyper",
+ "hyper 0.14.27",
  "parking_lot 0.11.2",
  "reqwest",
  "reqwest-middleware",
@@ -3982,6 +4284,18 @@ dependencies = [
  "anyhow",
  "chrono",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "rexpect"
+version = "0.5.0"
+source = "git+https://github.com/rust-cli/rexpect?branch=master#9eb61dd444f25307639367ac7e1a49d5a1915d55"
+dependencies = [
+ "comma",
+ "nix",
+ "regex",
+ "tempfile",
+ "thiserror",
 ]
 
 [[package]]
@@ -4068,7 +4382,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "unsigned-varint",
- "url",
+ "url 2.5.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -4082,7 +4396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
 dependencies = [
  "const-oid",
- "digest",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -4175,7 +4489,7 @@ version = "0.21.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "629648aced5775d558af50b2b4c7b02983a04b312126d45eeead26e7caa498b9"
 dependencies = [
- "log",
+ "log 0.4.20",
  "ring 0.17.7",
  "rustls-webpki",
  "sct",
@@ -4223,6 +4537,12 @@ name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "same-file"
@@ -4276,7 +4596,7 @@ checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der",
- "generic-array",
+ "generic-array 0.14.7",
  "subtle",
  "zeroize",
 ]
@@ -4368,7 +4688,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
 dependencies = [
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "serde",
  "thiserror",
 ]
@@ -4408,7 +4728,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time",
+ "time 0.3.30",
 ]
 
 [[package]]
@@ -4425,13 +4745,25 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+dependencies = [
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha-1"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4442,7 +4774,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4453,7 +4785,7 @@ checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4462,7 +4794,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -4520,7 +4852,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -4542,7 +4874,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -4600,11 +4932,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7a2b3c2bc9693bcb40870c4e9b5bf0d79f9cb46273321bf855ec513e919082"
 dependencies = [
  "base64 0.21.5",
- "digest",
+ "digest 0.10.7",
  "hex",
  "miette",
  "serde",
- "sha-1",
+ "sha-1 0.10.1",
  "sha2",
  "thiserror",
  "xxhash-rust",
@@ -4802,6 +5134,17 @@ dependencies = [
 
 [[package]]
 name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
+name = "time"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
@@ -4907,9 +5250,9 @@ dependencies = [
  "fallible-iterator",
  "futures-channel",
  "futures-util",
- "log",
+ "log 0.4.20",
  "parking_lot 0.12.1",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "phf",
  "pin-project-lite",
  "postgres-protocol",
@@ -4949,7 +5292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
- "log",
+ "log 0.4.20",
  "tokio",
  "tungstenite",
 ]
@@ -5052,9 +5395,9 @@ dependencies = [
  "h2",
  "http",
  "http-body",
- "hyper",
+ "hyper 0.14.27",
  "hyper-timeout",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "pin-project",
  "prost",
  "rustls-native-certs",
@@ -5128,7 +5471,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "log",
+ "log 0.4.20",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -5142,7 +5485,7 @@ checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
 dependencies = [
  "crossbeam-channel",
  "thiserror",
- "time",
+ "time 0.3.30",
  "tracing-subscriber",
 ]
 
@@ -5173,7 +5516,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
 dependencies = [
- "log",
+ "log 0.4.20",
  "once_cell",
  "tracing-core",
 ]
@@ -5184,7 +5527,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
- "log",
+ "log 0.4.20",
  "once_cell",
  "tracing-core",
 ]
@@ -5249,6 +5592,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "traitobject"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5265,13 +5614,19 @@ dependencies = [
  "data-encoding",
  "http",
  "httparse",
- "log",
+ "log 0.4.20",
  "rand 0.8.5",
  "sha1",
  "thiserror",
- "url",
+ "url 2.5.0",
  "utf-8",
 ]
+
+[[package]]
+name = "typeable"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 
 [[package]]
 name = "typed-builder"
@@ -5328,11 +5683,20 @@ dependencies = [
 
 [[package]]
 name = "unicase"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
+dependencies = [
+ "version_check 0.1.5",
+]
+
+[[package]]
+name = "unicase"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
 dependencies = [
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -5394,13 +5758,24 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
+dependencies = [
+ "idna 0.1.5",
+ "matches",
+ "percent-encoding 1.0.1",
+]
+
+[[package]]
+name = "url"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
  "idna 0.5.0",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "serde",
 ]
 
@@ -5486,7 +5861,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "url",
+ "url 2.5.0",
  "validator_derive",
 ]
 
@@ -5527,6 +5902,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"
@@ -5576,6 +5957,12 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -5597,7 +5984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
 dependencies = [
  "bumpalo",
- "log",
+ "log 0.4.20",
  "once_cell",
  "proc-macro2",
  "quote",
@@ -5686,6 +6073,32 @@ name = "webpki-roots"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
+
+[[package]]
+name = "websocket"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a1aba896516545a4cea196a12c04074854ab85d53bbaf22f9b79eddadde75a2"
+dependencies = [
+ "hyper 0.10.16",
+ "rand 0.6.5",
+ "unicase 1.4.2",
+ "url 1.7.2",
+ "websocket-base",
+]
+
+[[package]]
+name = "websocket-base"
+version = "0.26.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aec794b07318993d1db16156d5a9c750120597a5ee40c6b928d416186cb138"
+dependencies = [
+ "base64 0.10.1",
+ "bitflags 1.3.2",
+ "byteorder",
+ "rand 0.6.5",
+ "sha-1 0.8.2",
+]
 
 [[package]]
 name = "whoami"
@@ -5926,8 +6339,8 @@ dependencies = [
  "futures",
  "futures-timer",
  "http-types",
- "hyper",
- "log",
+ "hyper 0.14.27",
+ "log 0.4.20",
  "once_cell",
  "regex",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00ad3f3a942eee60335ab4342358c161ee296829e0d16ff42fc1d6cb07815467"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
+name = "assert_fs"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cd762e110c8ed629b11b6cde59458cc1c71de78ebbcc30099fc8e0403a2a2ec"
+dependencies = [
+ "anstyle",
+ "doc-comment",
+ "globwalk",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "tempfile",
+]
+
+[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,6 +485,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
 dependencies = [
  "tinyvec",
+]
+
+[[package]]
+name = "bstr"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "542f33a8835a0884b006a0c3df3dadd99c0c3f296ed26c2fdc8028e01ad6230c"
+dependencies = [
+ "memchr",
+ "regex-automata 0.4.3",
+ "serde",
 ]
 
 [[package]]
@@ -1062,6 +1103,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,6 +1166,12 @@ name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "downcast-rs"
@@ -1247,6 +1300,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "escargot"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "768064bd3a0e2bedcba91dc87ace90beea91acc41b6a01a3ca8e9aa8827461bf"
+dependencies = [
+ "log",
+ "once_cell",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,18 +1365,23 @@ name = "fission-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
+ "assert_fs",
  "async-trait",
  "clap",
  "config",
  "directories",
  "ed25519",
  "ed25519-dalek",
+ "escargot",
  "fission-core",
  "hickory-proto",
  "http-cache",
  "http-cache-reqwest",
  "http-cache-semantics",
  "inquire",
+ "once_cell",
+ "predicates",
  "rand 0.8.5",
  "reqwest",
  "reqwest-middleware",
@@ -1319,6 +1389,8 @@ dependencies = [
  "serde",
  "serde_json",
  "task-local-extensions",
+ "test-log",
+ "testresult",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1458,6 +1530,15 @@ checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1640,6 +1721,30 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "globset"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+dependencies = [
+ "bitflags 2.4.1",
+ "ignore",
+ "walkdir",
+]
 
 [[package]]
 name = "group"
@@ -2099,6 +2204,22 @@ name = "if_chain"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
+
+[[package]]
+name = "ignore"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata 0.4.3",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
 
 [[package]]
 name = "indexmap"
@@ -2812,6 +2933,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "ntapi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3370,6 +3497,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31c0052426df997c0cbd30789eb44ca097e3541717a7b8fa36b1c464ee7edebd"
 dependencies = [
  "vcpkg",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -4581,6 +4738,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
 name = "test-log"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5370,6 +5533,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "waker-fn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = "1.0"
 test-log = { version = "0.2", default-features = false, features = ["trace"] }
 testresult = "0.3"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "parking_lot", "registry"] }
-rs-ucan = { git = "https://github.com/fission-codes/rs-ucan/", branch = "matheus23/skip-rsa-len-check", revision = "643025b5bdb70ef7f6349cfa01361cfcc185d3ae" }
+rs-ucan = { git = "https://github.com/fission-codes/rs-ucan/", branch = "matheus23/skip-rsa-len-check" }
 url = { version = "2.3", features = ["serde"] }
 utoipa = { version = "3.1", features = ["uuid", "axum_extras"] }
 validator = { version = "0.16.0", features = ["derive"] }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,5 @@
 ignore:
   - "*/tests/*"
-  - "fission-cli/*"
 
 comment:
   layout: "reach, diff, flags, files"

--- a/deny.toml
+++ b/deny.toml
@@ -191,7 +191,7 @@ unknown-git = "deny"
 # if not specified. If it is specified but empty, no registries are allowed.
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
-allow-git = ["https://github.com/fission-codes/rs-ucan"]
+allow-git = ["https://github.com/fission-codes/rs-ucan", "https://github.com/rust-cli/rexpect"]
 
 [sources.allow-org]
 # 1 or more github.com organizations to allow git sources for

--- a/fission-cli/Cargo.toml
+++ b/fission-cli/Cargo.toml
@@ -59,7 +59,7 @@ test-log = { workspace = true }
 assert_fs = "1.1.1"
 escargot = "0.5.8"
 websocket = { version = "0.27.0", default-features = false, features = ["sync"] }
-rexpect = { git = "https://github.com/rust-cli/rexpect", branch = "master" }
+rexpect = { git = "https://github.com/rust-cli/rexpect", branch = "master", revision = "9eb61dd444f25307639367ac7e1a49d5a1915d55" }
 
 [[test]]
 name = "integration"

--- a/fission-cli/Cargo.toml
+++ b/fission-cli/Cargo.toml
@@ -59,7 +59,7 @@ test-log = { workspace = true }
 assert_fs = "1.1.1"
 escargot = "0.5.8"
 websocket = { version = "0.27.0", default-features = false, features = ["sync"] }
-rexpect = { git = "https://github.com/rust-cli/rexpect", branch = "master", revision = "9eb61dd444f25307639367ac7e1a49d5a1915d55" }
+rexpect = { git = "https://github.com/rust-cli/rexpect", branch = "master" }
 
 [[test]]
 name = "integration"

--- a/fission-cli/Cargo.toml
+++ b/fission-cli/Cargo.toml
@@ -47,3 +47,16 @@ hickory-proto = "0.24.0"
 http-cache-reqwest = "0.12.0"
 http-cache = { version = "0.17.0", default-features = false }
 http-cache-semantics = "1.0.1"
+
+[dev-dependencies]
+assert_cmd = "2.0"
+once_cell = { version = "1.18", default-features = false }
+predicates = "3.1.0"
+testresult = { workspace = true }
+test-log = { workspace = true }
+assert_fs = "1.1.1"
+escargot = "0.5.8"
+
+[[test]]
+name = "integration"
+path = "tests/main.rs"

--- a/fission-cli/Cargo.toml
+++ b/fission-cli/Cargo.toml
@@ -47,6 +47,8 @@ hickory-proto = "0.24.0"
 http-cache-reqwest = "0.12.0"
 http-cache = { version = "0.17.0", default-features = false }
 http-cache-semantics = "1.0.1"
+rand_chacha = "0.3.1"
+blake3 = "1.5.0"
 
 [dev-dependencies]
 assert_cmd = "2.0"
@@ -56,6 +58,8 @@ testresult = { workspace = true }
 test-log = { workspace = true }
 assert_fs = "1.1.1"
 escargot = "0.5.8"
+websocket = { version = "0.27.0", default-features = false, features = ["sync"] }
+rexpect = { git = "https://github.com/rust-cli/rexpect", branch = "master" }
 
 [[test]]
 name = "integration"

--- a/fission-cli/src/cli.rs
+++ b/fission-cli/src/cli.rs
@@ -9,6 +9,7 @@ use crate::{
 use anyhow::{anyhow, bail, Context, Result};
 use clap::{Parser, Subcommand};
 use ed25519::pkcs8::{spki::der::pem::LineEnding, DecodePrivateKey, EncodePrivateKey};
+use ed25519_dalek::SigningKey;
 use fission_core::{
     capabilities::{did::Did, fission::FissionAbility, indexing::IndexingAbility},
     common::{
@@ -20,6 +21,9 @@ use fission_core::{
 };
 use hickory_proto::rr::RecordType;
 use http_cache_reqwest::{CACacheManager, Cache, CacheMode, HttpCache, HttpCacheOptions};
+use inquire::ui::RenderConfig;
+use rand::SeedableRng;
+use rand_chacha::ChaCha12Rng;
 use reqwest::{header::CONTENT_TYPE, Client, Method};
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware, RequestBuilder};
 use rs_ucan::{
@@ -44,8 +48,11 @@ pub struct Cli {
     key_file: Option<PathBuf>,
     #[arg(
         long,
-        help = "Whether to turn off ansi terminal colors in log messages"
+        hide = true,
+        help = "Provide a seed for an in-memory DID. Used for testing."
     )]
+    key_seed: Option<String>,
+    #[arg(long, help = "Whether to turn off ansi terminal colors")]
     no_colors: bool,
     #[command(subcommand)]
     command: Commands,
@@ -104,7 +111,7 @@ impl Cli {
 
         match &self.command {
             Commands::Account(account) => {
-                let mut state = CliState::load(&settings).await?;
+                let mut state = CliState::load(&settings, self.key_seed.clone(), ansi).await?;
                 state.fetch_ucans().await?;
 
                 match &account.command {
@@ -153,7 +160,9 @@ impl Cli {
                         )?;
                         let did = Did(auth.account.did.to_string());
 
-                        let new_username = inquire::Text::new("Pick a new username:").prompt()?;
+                        let new_username = inquire::Text::new("Pick a new username:")
+                            .with_render_config(state.render_config)
+                            .prompt()?;
 
                         if new_username.contains('.') {
                             println!(
@@ -166,6 +175,7 @@ impl Cli {
                             let new_handle = Handle::from_unicode(&new_username)?;
 
                             inquire::Confirm::new("Have you verified that the DNS record is set?")
+                                .with_render_config(state.render_config)
                                 .prompt()?;
 
                             state
@@ -214,6 +224,7 @@ impl Cli {
 #[derive(Debug)]
 pub(crate) struct CliState<'s> {
     pub(crate) settings: &'s Settings,
+    pub(crate) render_config: RenderConfig,
     pub(crate) key: EdDidKey,
     pub(crate) client: ClientWithMiddleware,
     pub(crate) server_did: String,
@@ -221,8 +232,19 @@ pub(crate) struct CliState<'s> {
 }
 
 impl<'s> CliState<'s> {
-    async fn load(settings: &'s Settings) -> Result<CliState<'s>> {
-        let key = load_key(settings)?;
+    async fn load(
+        settings: &'s Settings,
+        key_seed: Option<String>,
+        colors: bool,
+    ) -> Result<CliState<'s>> {
+        let key = load_key(settings, key_seed)?;
+        tracing::info!(%key, "Generated or loaded DID");
+
+        let render_config = if colors {
+            RenderConfig::default_colored()
+        } else {
+            RenderConfig::empty()
+        };
 
         let client = ClientBuilder::new(Client::new())
             .with(LogAndHandleErrorMiddleware)
@@ -251,6 +273,7 @@ impl<'s> CliState<'s> {
 
         Ok(Self {
             settings,
+            render_config,
             key,
             client,
             server_did,
@@ -278,7 +301,10 @@ impl<'s> CliState<'s> {
     }
 
     async fn request_email_verification(&self) -> Result<(String, String)> {
-        let email = inquire::Text::new("What's your email address?").prompt()?;
+        let email = inquire::Text::new("What's your email address?")
+            .with_render_config(self.render_config)
+            .prompt()?;
+        tracing::info!(email, "Email entered");
 
         self.server_request(Method::POST, "/api/v0/auth/email/verify")?
             .json(&EmailVerifyRequest {
@@ -290,7 +316,9 @@ impl<'s> CliState<'s> {
         println!("Successfully requested an email verification code.");
 
         // TODO verify it's a 6 digit number. Allow retries.
-        let code = inquire::Text::new("Please enter the verification code:").prompt()?;
+        let code = inquire::Text::new("Please enter the verification code:")
+            .with_render_config(self.render_config)
+            .prompt()?;
 
         Ok((email, code))
     }
@@ -301,7 +329,9 @@ impl<'s> CliState<'s> {
         let (ucan, proofs) = self.issue_ucan(self.device_did(), FissionAbility::AccountCreate)?;
 
         // TODO Check for availablility. Allow retries.
-        let username = inquire::Text::new("Choose a username:").prompt()?;
+        let username = inquire::Text::new("Choose a username:")
+            .with_render_config(self.render_config)
+            .prompt()?;
         let username = Username::from_unicode(&username)?;
 
         let response: AccountAndAuth = self
@@ -325,7 +355,9 @@ impl<'s> CliState<'s> {
     }
 
     async fn link_account(&mut self) -> Result<Account> {
-        let username = inquire::Text::new("What's your username?").prompt()?;
+        let username = inquire::Text::new("What's your username?")
+            .with_render_config(self.render_config)
+            .prompt()?;
 
         let account_did = doh_request(
             &self.client,
@@ -461,7 +493,9 @@ impl<'s> CliState<'s> {
                         })
                         .collect();
 
-                    let account_name = inquire::Select::new(prompt, account_names).prompt()?;
+                    let account_name = inquire::Select::new(prompt, account_names)
+                        .with_render_config(self.render_config)
+                        .prompt()?;
 
                     accounts
                         .into_iter()
@@ -562,7 +596,14 @@ impl<'s> CliState<'s> {
     }
 }
 
-fn load_key(settings: &Settings) -> Result<EdDidKey> {
+fn load_key(settings: &Settings, key_seed: Option<String>) -> Result<EdDidKey> {
+    if let Some(key_seed) = key_seed {
+        tracing::info!(?key_seed, "Generating key from seed");
+        return Ok(EdDidKey::new(SigningKey::generate(
+            &mut ChaCha12Rng::from_seed(blake3::hash(key_seed.as_bytes()).into()),
+        )));
+    }
+
     let key_path = &settings.key_file;
 
     if let Some(dir) = key_path.parent() {
@@ -589,7 +630,6 @@ fn load_key(settings: &Settings) -> Result<EdDidKey> {
         file.read_to_string(&mut string)?;
         EdDidKey::from_pkcs8_pem(&string)?
     };
-    tracing::info!(%key, "Generated or loaded DID");
     Ok(key)
 }
 

--- a/fission-cli/src/cli.rs
+++ b/fission-cli/src/cli.rs
@@ -508,9 +508,10 @@ impl<'s> CliState<'s> {
                         })
                         .ok_or_else(|| anyhow!("Something went wrong. Couldn't select account."))?
                 } else {
-                    accounts.into_iter().next().ok_or_else(|| {
-                        anyhow!("Please provide the username in the command argument.")
-                    })?
+                    accounts
+                        .into_iter()
+                        .next()
+                        .ok_or_else(|| anyhow!("You don't seem to have access to an account yet. Try runing fission-cli account create."))?
                 }
             }
         })

--- a/fission-cli/src/main.rs
+++ b/fission-cli/src/main.rs
@@ -1,15 +1,9 @@
 use anyhow::Result;
 use clap::Parser;
 use fission_cli::{cli::Cli, settings::Settings};
-use tracing_subscriber::{prelude::*, util::SubscriberInitExt, EnvFilter};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
-        .with(EnvFilter::from_default_env())
-        .init();
-
     let cli = Cli::parse();
     let settings = Settings::load()?;
     cli.run(settings).await?;

--- a/fission-cli/src/settings.rs
+++ b/fission-cli/src/settings.rs
@@ -34,6 +34,8 @@ impl Settings {
 
         if path.exists() {
             builder = builder.add_source(File::with_name(&path.as_path().display().to_string()));
+        } else {
+            tracing::warn!(?path, "Couldn't find config file to load");
         }
 
         builder = builder.add_source(

--- a/fission-cli/src/settings.rs
+++ b/fission-cli/src/settings.rs
@@ -30,15 +30,20 @@ impl Settings {
     pub fn load() -> Result<Self> {
         let path = config_file();
 
-        let s = Config::builder()
-            .add_source(SerdeValueSource::from(Settings::default()))
-            .add_source(File::with_name(&path.as_path().display().to_string()))
-            .add_source(
-                Environment::with_prefix("FISSION")
-                    .separator("_")
-                    .try_parsing(true),
-            )
-            .build()?;
+        let mut builder = Config::builder().add_source(SerdeValueSource::from(Settings::default()));
+
+        if path.exists() {
+            builder = builder.add_source(File::with_name(&path.as_path().display().to_string()));
+        }
+
+        builder = builder.add_source(
+            Environment::with_prefix("FISSION")
+                .separator("_")
+                .try_parsing(true),
+        );
+
+        let s = builder.build()?;
+
         Ok(s.try_deserialize()?)
     }
 }

--- a/fission-cli/tests/cli.rs
+++ b/fission-cli/tests/cli.rs
@@ -1,0 +1,68 @@
+use anyhow::{bail, Result};
+use once_cell::sync::Lazy;
+use rexpect::{
+    process::wait::WaitStatus,
+    session::{Options, PtySession},
+    spawn_with_options,
+};
+use std::{path::PathBuf, process::Command};
+
+/// cargo always builds binaries before building the `[[test]]`s, so this should just exist
+pub static CLI_BIN: Lazy<PathBuf> = Lazy::new(|| assert_cmd::cargo::cargo_bin("fission-cli"));
+
+const REXPECT_OPTS: Options = Options {
+    strip_ansi_escape_codes: true,
+    timeout_ms: Some(2000),
+};
+
+pub struct Cli {
+    pub session: PtySession,
+}
+
+impl Cli {
+    pub fn run(cmd_fn: impl FnOnce(&mut Command) -> &mut Command) -> Result<Self> {
+        let mut cmd = Command::new(CLI_BIN.as_os_str());
+        cmd.arg("--no-colors");
+        cmd_fn(&mut cmd);
+
+        tracing::info!("Running a fission-cli process");
+
+        let session = spawn_with_options(cmd, REXPECT_OPTS)?;
+
+        Ok(Self { session })
+    }
+
+    pub fn expect(&mut self, output: &str) -> Result<()> {
+        tracing::info!(output, "Expecting to see output");
+        self.session.exp_string(output)?;
+        Ok(())
+    }
+
+    pub fn send_line(&mut self, input: &str) -> Result<()> {
+        tracing::info!(input, "Entering input");
+        self.session.send(input)?;
+        self.session.send("\r")?;
+        self.session.flush()?;
+        tracing::info!("Entered input");
+        Ok(())
+    }
+
+    pub fn expect_eof(&mut self) -> Result<()> {
+        tracing::info!("Waiting for the CLI process to exit");
+        self.session.exp_eof()?;
+        tracing::info!("CLI process exited");
+        Ok(())
+    }
+
+    pub fn expect_success(&mut self) -> Result<()> {
+        self.expect_eof()?;
+        match self.session.process.status() {
+            Some(WaitStatus::Exited(_, 0)) => Ok(()),
+            Some(WaitStatus::Exited(_, code)) => {
+                bail!("Expected successful exit, but got status code {code}")
+            }
+            Some(status) => bail!("Expected successful exit, but got {status:?}"),
+            None => bail!("Expected successful exit, but couldn't fetch process status"),
+        }
+    }
+}

--- a/fission-cli/tests/cli.rs
+++ b/fission-cli/tests/cli.rs
@@ -32,13 +32,15 @@ impl Cli {
         Ok(Self { session })
     }
 
-    pub fn expect(&mut self, output: &str) -> Result<()> {
+    pub fn expect(&mut self, output: impl AsRef<str>) -> Result<()> {
+        let output = output.as_ref();
         tracing::info!(output, "Expecting to see output");
         self.session.exp_string(output)?;
         Ok(())
     }
 
-    pub fn send_line(&mut self, input: &str) -> Result<()> {
+    pub fn send_line(&mut self, input: impl AsRef<str>) -> Result<()> {
+        let input = input.as_ref();
         tracing::info!(input, "Entering input");
         self.session.send(input)?;
         self.session.send("\r")?;

--- a/fission-cli/tests/cli.rs
+++ b/fission-cli/tests/cli.rs
@@ -23,6 +23,7 @@ impl Cli {
     pub fn run(cmd_fn: impl FnOnce(&mut Command) -> &mut Command) -> Result<Self> {
         let mut cmd = Command::new(CLI_BIN.as_os_str());
         cmd.arg("--no-colors");
+        cmd.arg("--key-seed=cli-tests");
         cmd_fn(&mut cmd);
 
         tracing::info!("Running a fission-cli process");

--- a/fission-cli/tests/main.rs
+++ b/fission-cli/tests/main.rs
@@ -85,7 +85,7 @@ fn test_cli_account_create() -> TestResult {
         cli.expect("Successfully requested an email verification code")?;
 
         let code = email_inbox.join().map_err(|_| "thread panicked")??;
-        cli.send_line(&code)?;
+        cli.send_line(code)?;
         cli.expect("Choose a username")?;
         cli.send_line("example")?;
         cli.expect("Successfully created your account")?;

--- a/fission-cli/tests/main.rs
+++ b/fission-cli/tests/main.rs
@@ -1,0 +1,64 @@
+//! Run via `cargo test -p fission-cli --test integration`
+use crate::server::FissionServer;
+use assert_cmd::assert::OutputAssertExt as _;
+use once_cell::sync::Lazy;
+use predicates::str::contains;
+use std::{path::PathBuf, process::Command, thread::scope};
+use testresult::TestResult;
+
+mod server;
+
+/// cargo always builds binaries before building the `[[test]]`s, so this should just exist
+static CLI_BIN: Lazy<PathBuf> = Lazy::new(|| assert_cmd::cargo::cargo_bin("fission-cli"));
+
+#[test_log::test]
+fn test_cli_helptext() -> TestResult {
+    Command::new(CLI_BIN.as_os_str())
+        .arg("--no-colors")
+        .arg("help")
+        .assert()
+        .try_success()?
+        .try_stdout(contains("fission-cli"))?
+        .try_stdout(contains("account"))?
+        .try_stdout(contains("paths"))?
+        .try_stdout(contains("help"))?
+        .try_stdout(contains("--key-file"))?;
+
+    Ok(())
+}
+
+#[test_log::test]
+fn test_cli_account_helptext() -> TestResult {
+    Command::new(CLI_BIN.as_os_str())
+        .arg("--no-colors")
+        .arg("account")
+        .arg("--help")
+        .assert()
+        .try_success()?
+        .try_stdout(contains("fission-cli"))?
+        .try_stdout(contains("create"))?
+        .try_stdout(contains("login"))?
+        .try_stdout(contains("list"))?
+        .try_stdout(contains("rename"))?
+        .try_stdout(contains("delete"))?
+        .try_stdout(contains("help"))?;
+
+    Ok(())
+}
+
+#[test_log::test]
+fn test_ci_account_list() -> TestResult {
+    scope(|s| {
+        let _server = FissionServer::spawn(s)?;
+
+        Command::new(CLI_BIN.as_os_str())
+            .arg("--no-colors")
+            .arg("account")
+            .arg("list")
+            .assert()
+            .try_success()?
+            .try_stdout(contains("You don't have access to any accounts yet"))?;
+
+        Ok(())
+    })
+}

--- a/fission-cli/tests/main.rs
+++ b/fission-cli/tests/main.rs
@@ -168,8 +168,6 @@ fn test_cli_account_delete() -> TestResult {
         cli.expect("Successfully deleted your account")?;
         cli.expect_success()?;
 
-        Err(anyhow!("Lol"))?;
-
         Ok(())
     })
 }

--- a/fission-cli/tests/main.rs
+++ b/fission-cli/tests/main.rs
@@ -168,6 +168,8 @@ fn test_cli_account_delete() -> TestResult {
         cli.expect("Successfully deleted your account")?;
         cli.expect_success()?;
 
+        Err(anyhow!("Lol"))?;
+
         Ok(())
     })
 }

--- a/fission-cli/tests/server.rs
+++ b/fission-cli/tests/server.rs
@@ -2,8 +2,8 @@ use anyhow::{anyhow, bail, Result};
 use escargot::CargoRun;
 use once_cell::sync::Lazy;
 use std::{
-    io::{stdout, BufRead, BufReader, Read, Write},
-    process::{Child, ChildStdout, Stdio},
+    io::{BufRead, BufReader, Read},
+    process::{Child, Stdio},
     sync::{Mutex, MutexGuard},
     thread::{Scope, ScopedJoinHandle},
 };
@@ -32,8 +32,16 @@ pub struct FissionServer<'a> {
 impl FissionServer<'_> {
     pub fn spawn<'s>(scope: &'s Scope<'s, '_>) -> Result<Self> {
         tracing::info!("Waiting for server lock");
-        let _guard = LOCK.lock().map_err(|_| anyhow!("Failed locking"))?;
+        let _guard = LOCK
+            .lock()
+            .map_err(|_| anyhow!("Failed locking server lock"))?;
         tracing::info!("Aquired server lock");
+
+        let rust_log = std::env::var("RUST_LOG")
+            .ok()
+            .map_or("fission_server=info".into(), |rl| {
+                format!("{rl},fission_server=info")
+            });
 
         let mut process = SERVER_BIN
             .command()
@@ -41,21 +49,32 @@ impl FissionServer<'_> {
             .arg("--no-colors")
             .arg("--ephemeral-db")
             .arg("--gen-key-if-needed")
+            .env("RUST_LOG", rust_log)
             .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
             .spawn()?;
 
-        // Take ownership of stdout
+        // Take ownership of outputs
         let mut child_stdout = process
             .stdout
             .take()
             .ok_or(anyhow!("no fission-server stdout"))?;
 
+        let child_stderr = process
+            .stderr
+            .take()
+            .ok_or(anyhow!("no fission-server stderr"))?;
+
+        // immediately start reprinting stderr
+        // We use print/eprint because that gets captured nicely by `cargo test`.
+        process_lines(scope, child_stderr, |line| eprint!("{line}"))?;
+
         // Wait for the server to start listening on a port
         tracing::info!("Waiting for the fission server API to be ready for requests");
         read_until(&mut child_stdout, "Application server listening")?;
 
-        // Then spawn a scoped thread to reprint everything to current system stdout:
-        reprint_stdout(scope, child_stdout)?;
+        // Then spawn a scoped thread to reprint stdout:
+        process_lines(scope, child_stdout, |line| print!("{line}"))?;
 
         tracing::info!("Server ready.");
         Ok(Self { process, _guard })
@@ -100,26 +119,29 @@ fn read_until(read: &mut impl std::io::Read, line_contains: &str) -> Result<()> 
             bail!("read_util: {line_contains:?} never appeared");
         }
 
-        stdout().lock().write_all(line.as_bytes())?;
+        print!("{line}");
         if line.contains(line_contains) {
             return Ok(());
         }
     }
 }
 
-fn reprint_stdout<'scope>(
+fn process_lines<'scope>(
     scope: &'scope Scope<'scope, '_>,
-    mut child_stdout: ChildStdout,
+    output: impl Read + Send + 'scope,
+    action: impl Fn(&String) -> () + Send + 'scope,
 ) -> Result<ScopedJoinHandle<'scope, Result<()>>> {
+    let mut reader = BufReader::new(output);
+    let mut line = String::new();
     Ok(scope.spawn(move || loop {
-        let mut buf = [0u8; 4096];
-        let bytes_read = child_stdout.read(&mut buf)?;
+        line.clear();
+        let bytes_read = reader.read_line(&mut line)?;
 
         // If bytes_read is 0, it indicates EOF.
         if bytes_read == 0 {
             return Ok::<(), anyhow::Error>(());
         }
 
-        stdout().lock().write_all(&buf[0..bytes_read])?;
+        action(&line);
     }))
 }

--- a/fission-cli/tests/server.rs
+++ b/fission-cli/tests/server.rs
@@ -45,7 +45,6 @@ impl FissionServer<'_> {
 
         let mut process = SERVER_BIN
             .command()
-            .arg("--close-on-stdin-close")
             .arg("--no-colors")
             .arg("--ephemeral-db")
             .arg("--gen-key-if-needed")

--- a/fission-cli/tests/server.rs
+++ b/fission-cli/tests/server.rs
@@ -40,6 +40,7 @@ impl FissionServer<'_> {
             .arg("--close-on-stdin-close")
             .arg("--no-colors")
             .arg("--ephemeral-db")
+            .arg("--gen-key-if-needed")
             .stdout(Stdio::piped())
             .spawn()?;
 

--- a/fission-cli/tests/server.rs
+++ b/fission-cli/tests/server.rs
@@ -1,0 +1,89 @@
+use anyhow::{anyhow, Result};
+use escargot::CargoRun;
+use once_cell::sync::Lazy;
+use std::{
+    io::{stdout, BufRead, BufReader, Read, Write},
+    process::{Child, ChildStdout, Stdio},
+    thread::{Scope, ScopedJoinHandle},
+};
+
+static SERVER_BIN: Lazy<CargoRun> = Lazy::new(|| {
+    // let temp = assert_fs::TempDir::new().expect("Couldn't create temporary directory");
+    tracing::info!("Possibly starting a fission-server build");
+    let cargo_run = escargot::CargoBuild::new()
+        .bin("fission-server")
+        .current_target()
+        .manifest_path("../fission-server/Cargo.toml")
+        .run()
+        .expect("fission-server binary build failed");
+    tracing::info!(path = ?cargo_run.path(), exists = ?cargo_run.path().exists(), "fission-server binary ready");
+    cargo_run
+});
+
+pub struct FissionServer {
+    process: Child,
+}
+
+impl FissionServer {
+    pub fn spawn<'s>(scope: &'s Scope<'s, '_>) -> Result<Self> {
+        let mut process = SERVER_BIN
+            .command()
+            .arg("--close-on-stdin-close")
+            .arg("--no-colors")
+            .stdout(Stdio::piped())
+            .spawn()?;
+
+        // Take ownership of stdout
+        let mut child_stdout = process
+            .stdout
+            .take()
+            .ok_or(anyhow!("no fission-server stdout"))?;
+
+        // Wait for the server to start listening on a port
+        read_until(&mut child_stdout, "Application server listening")?;
+
+        // Then spawn a scoped thread to reprint everything to current system stdout:
+        reprint_stdout(scope, child_stdout)?;
+
+        Ok(Self { process })
+    }
+}
+
+impl Drop for FissionServer {
+    fn drop(&mut self) {
+        tracing::info!("Killing the fission server process");
+        if let Err(e) = self.process.kill() {
+            eprintln!("Error trying to kill the fission server process: {e:?}");
+        }
+    }
+}
+
+fn read_until(read: &mut impl std::io::Read, line_contains: &str) -> Result<()> {
+    let mut reader = BufReader::new(read);
+    let line = &mut String::new();
+    loop {
+        line.clear();
+        reader.read_line(line)?;
+        stdout().lock().write_all(line.as_bytes())?;
+        if line.contains(line_contains) {
+            return Ok(());
+        }
+    }
+}
+
+fn reprint_stdout<'scope>(
+    scope: &'scope Scope<'scope, '_>,
+    mut child_stdout: ChildStdout,
+) -> Result<ScopedJoinHandle<'scope, Result<()>>> {
+    Ok(scope.spawn(move || loop {
+        let mut buf = [0u8; 4096];
+        let bytes_read = child_stdout.read(&mut buf)?;
+
+        // If bytes_read is 0, it indicates EOF.
+        if bytes_read == 0 {
+            return Ok::<(), anyhow::Error>(());
+        }
+
+        stdout().lock().write_all(&buf[0..bytes_read])?;
+    }))
+}

--- a/fission-cli/tests/server.rs
+++ b/fission-cli/tests/server.rs
@@ -30,6 +30,7 @@ impl FissionServer {
             .command()
             .arg("--close-on-stdin-close")
             .arg("--no-colors")
+            .arg("--ephemeral-db")
             .stdout(Stdio::piped())
             .spawn()?;
 

--- a/fission-server/Cargo.toml
+++ b/fission-server/Cargo.toml
@@ -115,6 +115,7 @@ ed25519 = { workspace = true }
 ed25519-dalek = { workspace = true }
 libipld = "0.16.0"
 blake3 = "1.4.1"
+uuid = "1.4.1"
 erased-serde = "0.3.31"
 
 [dev-dependencies]
@@ -123,7 +124,6 @@ assert_matches = "1.5.0"
 blake3 = "1.4.1"
 test-log = { workspace = true }
 testresult = { workspace = true }
-uuid = "1.4.1"
 wiremock = "0.5"
 
 [features]

--- a/fission-server/Cargo.toml
+++ b/fission-server/Cargo.toml
@@ -127,6 +127,7 @@ uuid = "1.4.1"
 wiremock = "0.5"
 
 [features]
+test_utils = []
 console = ["console-subscriber"]
 default = []
 

--- a/fission-server/src/extract/authority.rs
+++ b/fission-server/src/extract/authority.rs
@@ -174,7 +174,7 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn extract_authority() -> TestResult {
-        let ctx = TestContext::new().await;
+        let ctx = &TestContext::new().await?;
         let issuer = &EdDidKey::generate();
 
         // Test if request requires a valid UCAN
@@ -213,7 +213,7 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn extract_authority_no_auth_header() -> TestResult {
-        let ctx = TestContext::new().await;
+        let ctx = &TestContext::new().await?;
 
         // Test if request requires a valid UCAN
         async fn authorized_get(

--- a/fission-server/src/lib.rs
+++ b/fission-server/src/lib.rs
@@ -25,5 +25,5 @@ pub mod setups;
 pub mod tracer;
 pub mod tracing_layers;
 
-#[cfg(test)]
-mod test_utils;
+#[cfg(any(feature = "test_utils", test))]
+pub mod test_utils;

--- a/fission-server/src/lib.rs
+++ b/fission-server/src/lib.rs
@@ -25,5 +25,4 @@ pub mod setups;
 pub mod tracer;
 pub mod tracing_layers;
 
-#[cfg(any(feature = "test_utils", test))]
 pub mod test_utils;

--- a/fission-server/src/models/capability_indexing.rs
+++ b/fission-server/src/models/capability_indexing.rs
@@ -350,8 +350,8 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_find_ucan_by_audience_single() -> TestResult {
-        let ctx = TestContext::new().await;
-        let conn = &mut ctx.get_db_conn().await;
+        let ctx = &TestContext::new().await?;
+        let conn = &mut ctx.get_db_conn().await?;
 
         let issuer = EdDidKey::generate();
         let audience = EdDidKey::generate();
@@ -380,8 +380,8 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_find_ucan_by_audience_transitive() -> TestResult {
-        let ctx = TestContext::new().await;
-        let conn = &mut ctx.get_db_conn().await;
+        let ctx = &TestContext::new().await?;
+        let conn = &mut ctx.get_db_conn().await?;
 
         let alice = EdDidKey::generate();
         let bob = EdDidKey::generate();
@@ -423,8 +423,8 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_find_ucan_by_audience_only_matching_resource() -> TestResult {
-        let ctx = TestContext::new().await;
-        let conn = &mut ctx.get_db_conn().await;
+        let ctx = &TestContext::new().await?;
+        let conn = &mut ctx.get_db_conn().await?;
 
         let alice = EdDidKey::generate();
         let bob = EdDidKey::generate();

--- a/fission-server/src/routes/account.rs
+++ b/fission-server/src/routes/account.rs
@@ -492,17 +492,16 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_create_account_ok() -> TestResult {
-        let ctx = TestContext::new().await;
+        let ctx = &TestContext::new().await?;
 
         let username = "oedipa";
         let email = "oedipa@trystero.com";
         let issuer = &EdDidKey::generate();
 
-        let (status, auth) =
-            create_account::<AccountAndAuth>(username, email, issuer, &ctx).await?;
+        let (status, auth) = create_account::<AccountAndAuth>(username, email, issuer, ctx).await?;
 
         assert_eq!(status, StatusCode::CREATED);
-        assert_eq!(auth.account.username, Some(ctx.user_handle(username)));
+        assert_eq!(auth.account.username, Some(ctx.user_handle(username)?));
         assert_eq!(auth.account.email, Some(email.to_string()));
         assert!(auth
             .ucans
@@ -514,19 +513,19 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_create_account_same_username_conflict() -> TestResult {
-        let ctx = TestContext::new().await;
+        let ctx = &TestContext::new().await?;
 
         let username = "oedipa";
         let email = "oedipa@trystero.com";
         let issuer = &EdDidKey::generate();
 
-        create_account::<AccountAndAuth>(username, email, issuer, &ctx).await?;
+        create_account::<AccountAndAuth>(username, email, issuer, ctx).await?;
 
         let username = "oedipa";
         let email = "oedipa2@trystero.com";
         let issuer = &EdDidKey::generate();
 
-        let (status, _) = create_account::<Value>(username, email, issuer, &ctx).await?;
+        let (status, _) = create_account::<Value>(username, email, issuer, ctx).await?;
 
         assert_eq!(status, StatusCode::CONFLICT);
 
@@ -535,7 +534,7 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_create_account_err_wrong_code() -> TestResult {
-        let ctx = TestContext::new().await;
+        let ctx = &TestContext::new().await?;
 
         let username = "oedipa";
         let email = "oedipa@trystero.com";
@@ -589,18 +588,18 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_get_account_ok() -> TestResult {
-        let ctx = TestContext::new().await;
+        let ctx = &TestContext::new().await?;
 
         let username = "donnie";
         let email = "donnie@example.com";
         let issuer = &EdDidKey::generate();
 
-        let (_, auth) = create_account(username, email, issuer, &ctx).await?;
+        let (_, auth) = create_account(username, email, issuer, ctx).await?;
 
-        let (status, body) = get_account::<Account>(&auth, issuer, &ctx).await?;
+        let (status, body) = get_account::<Account>(&auth, issuer, ctx).await?;
 
         assert_eq!(status, StatusCode::OK);
-        assert_eq!(body.username, Some(ctx.user_handle(username)));
+        assert_eq!(body.username, Some(ctx.user_handle(username)?));
         assert_eq!(body.email, Some(email.to_string()));
 
         Ok(())
@@ -608,17 +607,17 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_patch_account_ok() -> TestResult {
-        let ctx = TestContext::new().await;
+        let ctx = &TestContext::new().await?;
 
         let username = "oedipa";
         let username2 = "oedipa2";
         let email = "oedipa@trystero.com";
         let issuer = &EdDidKey::generate();
 
-        let (_, auth) = create_account::<AccountAndAuth>(username, email, issuer, &ctx).await?;
+        let (_, auth) = create_account::<AccountAndAuth>(username, email, issuer, ctx).await?;
 
         let (status, resp) =
-            patch_username::<SuccessResponse>(username2, &auth, issuer, &ctx).await?;
+            patch_username::<SuccessResponse>(username2, &auth, issuer, ctx).await?;
 
         assert_eq!(status, StatusCode::OK);
         assert!(resp.success);
@@ -628,15 +627,15 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_delete_account_ok() -> TestResult {
-        let ctx = TestContext::new().await;
+        let ctx = &TestContext::new().await?;
 
         let username = "oedipa";
         let email = "oedipa@trystero.com";
         let issuer = &EdDidKey::generate();
 
-        let (_, auth) = create_account::<AccountAndAuth>(username, email, issuer, &ctx).await?;
+        let (_, auth) = create_account::<AccountAndAuth>(username, email, issuer, ctx).await?;
 
-        let (status, account) = delete_account::<Account>(&auth, issuer, &ctx).await?;
+        let (status, account) = delete_account::<Account>(&auth, issuer, ctx).await?;
 
         assert_eq!(status, StatusCode::OK);
         assert_eq!(account.username, auth.account.username);
@@ -648,19 +647,19 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_patch_revoked_account_err() -> TestResult {
-        let ctx = TestContext::new().await;
+        let ctx = &TestContext::new().await?;
 
         let username = "oedipa";
         let username2 = "oedipa2";
         let email = "oedipa@trystero.com";
         let issuer = &EdDidKey::generate();
 
-        let (_, auth) = create_account::<AccountAndAuth>(username, email, issuer, &ctx).await?;
+        let (_, auth) = create_account::<AccountAndAuth>(username, email, issuer, ctx).await?;
 
-        delete_account::<Account>(&auth, issuer, &ctx).await?;
+        delete_account::<Account>(&auth, issuer, ctx).await?;
 
         let (status, _) =
-            patch_username::<serde_json::Value>(username2, &auth, issuer, &ctx).await?;
+            patch_username::<serde_json::Value>(username2, &auth, issuer, ctx).await?;
 
         assert_eq!(status, StatusCode::FORBIDDEN);
 
@@ -669,18 +668,18 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_account_link_ok() -> TestResult {
-        let ctx = TestContext::new().await;
+        let ctx = &TestContext::new().await?;
 
         let username = "oedipa";
         let email = "oedipa@trystero.com";
         let issuer = &EdDidKey::generate();
 
-        let (_, auth) = create_account::<AccountAndAuth>(username, email, issuer, &ctx).await?;
+        let (_, auth) = create_account::<AccountAndAuth>(username, email, issuer, ctx).await?;
 
         let issuer2 = &EdDidKey::generate();
 
         let (status, link_response) =
-            link_account::<AccountAndAuth>(&auth.account.did, email, issuer2, &ctx).await?;
+            link_account::<AccountAndAuth>(&auth.account.did, email, issuer2, ctx).await?;
 
         assert_eq!(status, StatusCode::OK);
         assert_eq!(link_response.account.did, auth.account.did);
@@ -691,18 +690,18 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_account_link_unknown_did_not_found() -> TestResult {
-        let ctx = TestContext::new().await;
+        let ctx = &TestContext::new().await?;
 
         let username = "oedipa";
         let email = "oedipa@trystero.com";
         let issuer = &EdDidKey::generate();
 
-        create_account::<AccountAndAuth>(username, email, issuer, &ctx).await?;
+        create_account::<AccountAndAuth>(username, email, issuer, ctx).await?;
 
         let issuer2 = &EdDidKey::generate();
 
         let (status, _) =
-            link_account::<Value>(EdDidKey::generate().did_as_str(), email, issuer2, &ctx).await?;
+            link_account::<Value>(EdDidKey::generate().did_as_str(), email, issuer2, ctx).await?;
 
         assert_eq!(status, StatusCode::NOT_FOUND);
 
@@ -711,19 +710,19 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_account_link_wrong_email_forbidden() -> TestResult {
-        let ctx = TestContext::new().await;
+        let ctx = &TestContext::new().await?;
 
         let username = "oedipa";
         let email = "oedipa@trystero.com";
         let issuer = &EdDidKey::generate();
 
-        let (_, response) = create_account::<AccountAndAuth>(username, email, issuer, &ctx).await?;
+        let (_, response) = create_account::<AccountAndAuth>(username, email, issuer, ctx).await?;
 
         let issuer2 = &EdDidKey::generate();
         let email2 = "someone.else@trystero.com";
 
         let (status, _) =
-            link_account::<Value>(&response.account.did, email2, issuer2, &ctx).await?;
+            link_account::<Value>(&response.account.did, email2, issuer2, ctx).await?;
 
         assert_eq!(status, StatusCode::FORBIDDEN);
 
@@ -732,15 +731,15 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_patch_handle_invalid_err() -> TestResult {
-        let ctx = TestContext::new().await;
+        let ctx = &TestContext::new().await?;
 
         let username = "oedipa";
         let email = "oedipa@trystero.com";
         let issuer = &EdDidKey::generate();
 
-        let (_, auth) = create_account::<AccountAndAuth>(username, email, issuer, &ctx).await?;
+        let (_, auth) = create_account::<AccountAndAuth>(username, email, issuer, ctx).await?;
 
-        let (status, _) = patch_handle::<Value>("oedipa.example.com", &auth, issuer, &ctx).await?;
+        let (status, _) = patch_handle::<Value>("oedipa.example.com", &auth, issuer, ctx).await?;
 
         assert_eq!(status, StatusCode::FORBIDDEN);
 
@@ -749,18 +748,18 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_patch_handle_ok() -> TestResult {
-        let ctx = TestContext::new().await;
+        let ctx = &TestContext::new().await?;
 
         let username = "oedipa";
         let email = "oedipa@trystero.com";
         let issuer = &EdDidKey::generate();
 
-        let (_, auth) = create_account::<AccountAndAuth>(username, email, issuer, &ctx).await?;
+        let (_, auth) = create_account::<AccountAndAuth>(username, email, issuer, ctx).await?;
 
-        register_test_dns_handle(username, auth.account.did.clone(), &ctx).await?;
+        register_test_dns_handle(username, auth.account.did.clone(), ctx).await?;
 
         let (status, response) =
-            patch_handle::<SuccessResponse>("oedipa.test", &auth, issuer, &ctx).await?;
+            patch_handle::<SuccessResponse>("oedipa.test", &auth, issuer, ctx).await?;
 
         assert_eq!(status, StatusCode::OK);
         assert!(response.success);
@@ -770,18 +769,18 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_patch_handle_wrong_did_err() -> TestResult {
-        let ctx = TestContext::new().await;
+        let ctx = &TestContext::new().await?;
 
         let username = "oedipa";
         let email = "oedipa@trystero.com";
         let issuer = &EdDidKey::generate();
 
-        let (_, auth) = create_account::<AccountAndAuth>(username, email, issuer, &ctx).await?;
+        let (_, auth) = create_account::<AccountAndAuth>(username, email, issuer, ctx).await?;
 
         let wrong_did = EdDidKey::generate().did();
-        register_test_dns_handle(username, wrong_did, &ctx).await?;
+        register_test_dns_handle(username, wrong_did, ctx).await?;
 
-        let (status, _) = patch_handle::<Value>("oedipa.test", &auth, issuer, &ctx).await?;
+        let (status, _) = patch_handle::<Value>("oedipa.test", &auth, issuer, ctx).await?;
 
         assert_eq!(status, StatusCode::FORBIDDEN);
 
@@ -790,19 +789,19 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_handle_is_returned_as_username() -> TestResult {
-        let ctx = TestContext::new().await;
+        let ctx = &TestContext::new().await?;
 
         let username = "oedipa";
         let email = "oedipa@trystero.com";
         let issuer = &EdDidKey::generate();
 
-        let (_, auth) = create_account::<AccountAndAuth>(username, email, issuer, &ctx).await?;
+        let (_, auth) = create_account::<AccountAndAuth>(username, email, issuer, ctx).await?;
 
-        register_test_dns_handle(username, auth.account.did.clone(), &ctx).await?;
+        register_test_dns_handle(username, auth.account.did.clone(), ctx).await?;
 
-        patch_handle::<SuccessResponse>("oedipa.test", &auth, issuer, &ctx).await?;
+        patch_handle::<SuccessResponse>("oedipa.test", &auth, issuer, ctx).await?;
 
-        let (_, account) = get_account::<Account>(&auth, issuer, &ctx).await?;
+        let (_, account) = get_account::<Account>(&auth, issuer, ctx).await?;
 
         assert_eq!(account.username, Some(Handle::from_str("oedipa.test")?));
 
@@ -811,28 +810,28 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_delete_handle_causes_username_to_be_reset() -> TestResult {
-        let ctx = TestContext::new().await;
+        let ctx = &TestContext::new().await?;
 
         let username = "oedipa";
         let email = "oedipa@trystero.com";
         let issuer = &EdDidKey::generate();
 
-        let (_, auth) = create_account::<AccountAndAuth>(username, email, issuer, &ctx).await?;
+        let (_, auth) = create_account::<AccountAndAuth>(username, email, issuer, ctx).await?;
 
-        register_test_dns_handle(username, auth.account.did.clone(), &ctx).await?;
+        register_test_dns_handle(username, auth.account.did.clone(), ctx).await?;
 
-        patch_handle::<SuccessResponse>("oedipa.test", &auth, issuer, &ctx).await?;
+        patch_handle::<SuccessResponse>("oedipa.test", &auth, issuer, ctx).await?;
 
-        let (_, account) = get_account::<Account>(&auth, issuer, &ctx).await?;
+        let (_, account) = get_account::<Account>(&auth, issuer, ctx).await?;
 
         assert_eq!(account.username, Some(Handle::from_str("oedipa.test")?));
 
-        let (status, response) = delete_handle::<SuccessResponse>(&auth, issuer, &ctx).await?;
+        let (status, response) = delete_handle::<SuccessResponse>(&auth, issuer, ctx).await?;
 
         assert_eq!(status, StatusCode::OK);
         assert!(response.success);
 
-        let (_, account) = get_account::<Account>(&auth, issuer, &ctx).await?;
+        let (_, account) = get_account::<Account>(&auth, issuer, ctx).await?;
 
         assert_eq!(
             account.username,
@@ -844,16 +843,16 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_get_member_number_starts_at_one() -> TestResult {
-        let ctx = TestContext::new().await;
+        let ctx = &TestContext::new().await?;
 
         let username = "oedipa";
         let email = "oedipa@trystero.com";
         let issuer = &EdDidKey::generate();
 
-        let (_, auth) = create_account::<AccountAndAuth>(username, email, issuer, &ctx).await?;
+        let (_, auth) = create_account::<AccountAndAuth>(username, email, issuer, ctx).await?;
 
         let (status, response) =
-            get_member_number::<MemberNumberResponse>(&auth, issuer, &ctx).await?;
+            get_member_number::<MemberNumberResponse>(&auth, issuer, ctx).await?;
 
         assert_eq!(status, StatusCode::OK);
         assert_eq!(response.member_number, 1);
@@ -863,16 +862,16 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_member_number_increases() -> TestResult {
-        let ctx = TestContext::new().await;
+        let ctx = &TestContext::new().await?;
 
         let username = "oedipa";
         let email = "oedipa@trystero.com";
         let issuer = &EdDidKey::generate();
 
-        let (_, auth) = create_account::<AccountAndAuth>(username, email, issuer, &ctx).await?;
+        let (_, auth) = create_account::<AccountAndAuth>(username, email, issuer, ctx).await?;
 
         let (status, response_one) =
-            get_member_number::<MemberNumberResponse>(&auth, issuer, &ctx).await?;
+            get_member_number::<MemberNumberResponse>(&auth, issuer, ctx).await?;
 
         assert_eq!(status, StatusCode::OK);
 
@@ -880,10 +879,10 @@ mod tests {
         let email = "oedipa2@trystero.com";
         let issuer = &EdDidKey::generate();
 
-        let (_, auth) = create_account::<AccountAndAuth>(username, email, issuer, &ctx).await?;
+        let (_, auth) = create_account::<AccountAndAuth>(username, email, issuer, ctx).await?;
 
         let (status, response_two) =
-            get_member_number::<MemberNumberResponse>(&auth, issuer, &ctx).await?;
+            get_member_number::<MemberNumberResponse>(&auth, issuer, ctx).await?;
 
         assert_eq!(status, StatusCode::OK);
         assert_eq!(response_two.member_number, response_one.member_number + 1);

--- a/fission-server/src/routes/capability_indexing.rs
+++ b/fission-server/src/routes/capability_indexing.rs
@@ -50,10 +50,8 @@ pub async fn get_capabilities<S: ServerSetup>(
 mod tests {
     use super::*;
     use crate::{
-        db::Conn,
-        error::ErrorResponse,
-        models::capability_indexing::index_ucan,
-        test_utils::{route_builder::RouteBuilder, test_context::TestContext},
+        db::Conn, error::ErrorResponse, models::capability_indexing::index_ucan,
+        test_utils::test_context::TestContext,
     };
     use anyhow::Result;
     use assert_matches::assert_matches;
@@ -64,7 +62,6 @@ mod tests {
         capability::Capability,
         semantics::{ability::TopAbility, caveat::EmptyCaveat},
         ucan::Ucan,
-        DefaultFact,
     };
     use testresult::TestResult;
 
@@ -97,11 +94,11 @@ mod tests {
             ))
             .sign(requestor)?;
 
-        let (status, response) =
-            RouteBuilder::<DefaultFact>::new(ctx.app(), Method::GET, "/api/v0/capabilities")
-                .with_ucan(auth)
-                .into_json_response::<UcansResponse>()
-                .await?;
+        let (status, response) = ctx
+            .request(Method::GET, "/api/v0/capabilities")
+            .with_ucan(auth)
+            .into_json_response::<UcansResponse>()
+            .await?;
 
         Ok((status, response))
     }
@@ -140,10 +137,10 @@ mod tests {
 
         index_ucan(&ucan, conn).await?;
 
-        let (status, _) =
-            RouteBuilder::<DefaultFact>::new(ctx.app(), Method::GET, "/api/v0/capabilities")
-                .into_json_response::<ErrorResponse>()
-                .await?;
+        let (status, _) = ctx
+            .request(Method::GET, "/api/v0/capabilities")
+            .into_json_response::<ErrorResponse>()
+            .await?;
 
         assert_eq!(status, StatusCode::UNAUTHORIZED);
 

--- a/fission-server/src/routes/capability_indexing.rs
+++ b/fission-server/src/routes/capability_indexing.rs
@@ -108,15 +108,15 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_get_capabilities_ok() -> TestResult {
-        let ctx = TestContext::new().await;
-        let conn = &mut ctx.get_db_conn().await;
+        let ctx = &TestContext::new().await?;
+        let conn = &mut ctx.get_db_conn().await?;
 
         let device = &EdDidKey::generate();
         let server = ctx.server_did();
 
         let ucan = index_test_ucan(server, device, server.did(), conn).await?;
 
-        let (status, response) = fetch_capabilities(device, &ctx).await?;
+        let (status, response) = fetch_capabilities(device, ctx).await?;
         assert_eq!(status, StatusCode::OK);
 
         let ucans = response.ucans.values().into_iter().collect::<Vec<_>>();
@@ -127,8 +127,8 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_get_capabilities_unauthorized() -> TestResult {
-        let ctx = TestContext::new().await;
-        let conn = &mut ctx.get_db_conn().await;
+        let ctx = &TestContext::new().await?;
+        let conn = &mut ctx.get_db_conn().await?;
 
         let device = &EdDidKey::generate();
         let server = ctx.server_did();
@@ -152,8 +152,8 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_get_capabilities_filtered_by_audience() -> TestResult {
-        let ctx = TestContext::new().await;
-        let conn = &mut ctx.get_db_conn().await;
+        let ctx = &TestContext::new().await?;
+        let conn = &mut ctx.get_db_conn().await?;
 
         let device = &EdDidKey::generate();
         let device_other = &EdDidKey::generate();
@@ -162,7 +162,7 @@ mod tests {
         // Index a test UCAN from `server` -> `device_other`
         let ucan_other = index_test_ucan(server, device_other, server.did(), conn).await?;
         // Requesting UCANs delegated to `device` should end up empty
-        let (status, response) = fetch_capabilities(device, &ctx).await?;
+        let (status, response) = fetch_capabilities(device, ctx).await?;
 
         assert_eq!(status, StatusCode::OK);
         assert!(response.ucans.is_empty());
@@ -171,8 +171,8 @@ mod tests {
         let ucan = index_test_ucan(server, device, server.did(), conn).await?;
 
         // Requesting UCANs should only return the ones that end in the relevant issuer's DID
-        let (_, response) = fetch_capabilities(device, &ctx).await?;
-        let (_, response_other) = fetch_capabilities(device_other, &ctx).await?;
+        let (_, response) = fetch_capabilities(device, ctx).await?;
+        let (_, response_other) = fetch_capabilities(device_other, ctx).await?;
 
         let ucans = response.ucans.into_values().into_iter().collect::<Vec<_>>();
         let ucans_other = response_other
@@ -188,8 +188,8 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_get_capabilities_fetches_whole_chain() -> TestResult {
-        let ctx = TestContext::new().await;
-        let conn = &mut ctx.get_db_conn().await;
+        let ctx = &TestContext::new().await?;
+        let conn = &mut ctx.get_db_conn().await?;
 
         let id_one = &EdDidKey::generate();
         let id_two = &EdDidKey::generate();
@@ -198,7 +198,7 @@ mod tests {
         let ucan_one = index_test_ucan(server, id_one, server.did(), conn).await?;
         let ucan_two = index_test_ucan(id_one, id_two, server.did(), conn).await?;
 
-        let (status, response) = fetch_capabilities(id_two, &ctx).await?;
+        let (status, response) = fetch_capabilities(id_two, ctx).await?;
 
         assert_eq!(status, StatusCode::OK);
 

--- a/fission-server/src/routes/doh.rs
+++ b/fission-server/src/routes/doh.rs
@@ -86,7 +86,7 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_dns_json_soa() -> TestResult {
-        let ctx = TestContext::new().await;
+        let ctx = &TestContext::new().await?;
 
         let (status, body) = RouteBuilder::<DefaultFact>::new(
             ctx.app(),
@@ -133,8 +133,8 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_dns_json_did_username_ok() -> TestResult {
-        let ctx = TestContext::new().await;
-        let mut conn = ctx.get_db_conn().await;
+        let ctx = &TestContext::new().await?;
+        let conn = &mut ctx.get_db_conn().await?;
 
         let username = "donnie";
         let email = "donnie@example.com";
@@ -146,7 +146,7 @@ mod tests {
                 accounts::email.eq(email),
                 accounts::did.eq(did),
             ))
-            .execute(&mut conn)
+            .execute(conn)
             .await?;
 
         let (status, body) = RouteBuilder::<DefaultFact>::new(
@@ -198,7 +198,7 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_dns_json_did_username_err_not_found() -> TestResult {
-        let ctx = TestContext::new().await;
+        let ctx = &TestContext::new().await?;
         let username = "donnie";
 
         let (status, body) = RouteBuilder::<DefaultFact>::new(

--- a/fission-server/src/routes/doh.rs
+++ b/fission-server/src/routes/doh.rs
@@ -70,16 +70,12 @@ pub async fn post<S: ServerSetup>(
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        db::schema::accounts,
-        test_utils::{route_builder::RouteBuilder, test_context::TestContext},
-    };
+    use crate::{db::schema::accounts, test_utils::test_context::TestContext};
     use diesel::ExpressionMethods;
     use diesel_async::RunQueryDsl;
     use http::{Method, StatusCode};
     use mime::Mime;
     use pretty_assertions::assert_eq;
-    use rs_ucan::DefaultFact;
     use serde_json::json;
     use std::str::FromStr;
     use testresult::TestResult;
@@ -88,14 +84,14 @@ mod tests {
     async fn test_dns_json_soa() -> TestResult {
         let ctx = &TestContext::new().await?;
 
-        let (status, body) = RouteBuilder::<DefaultFact>::new(
-            ctx.app(),
-            Method::GET,
-            format!("/dns-query?name={}&type={}", "localhost", "soa"),
-        )
-        .with_accept_mime(Mime::from_str("application/dns-json")?)
-        .into_json_response::<serde_json::Value>()
-        .await?;
+        let (status, body) = ctx
+            .request(
+                Method::GET,
+                format!("/dns-query?name={}&type={}", "localhost", "soa"),
+            )
+            .with_accept_mime(Mime::from_str("application/dns-json")?)
+            .into_json_response::<serde_json::Value>()
+            .await?;
 
         assert_eq!(status, StatusCode::OK);
         assert_eq!(
@@ -149,18 +145,18 @@ mod tests {
             .execute(conn)
             .await?;
 
-        let (status, body) = RouteBuilder::<DefaultFact>::new(
-            ctx.app(),
-            Method::GET,
-            format!(
-                "/dns-query?name={}&type={}",
-                format_args!("_did.{}.localhost", username),
-                "txt"
-            ),
-        )
-        .with_accept_mime(Mime::from_str("application/dns-json")?)
-        .into_json_response::<serde_json::Value>()
-        .await?;
+        let (status, body) = ctx
+            .request(
+                Method::GET,
+                format!(
+                    "/dns-query?name={}&type={}",
+                    format_args!("_did.{}.localhost", username),
+                    "txt"
+                ),
+            )
+            .with_accept_mime(Mime::from_str("application/dns-json")?)
+            .into_json_response::<serde_json::Value>()
+            .await?;
 
         assert_eq!(status, StatusCode::OK);
         assert_eq!(
@@ -201,18 +197,18 @@ mod tests {
         let ctx = &TestContext::new().await?;
         let username = "donnie";
 
-        let (status, body) = RouteBuilder::<DefaultFact>::new(
-            ctx.app(),
-            Method::GET,
-            format!(
-                "/dns-query?name={}&type={}",
-                format_args!("_did.{}.localhost", username),
-                "txt"
-            ),
-        )
-        .with_accept_mime(Mime::from_str("application/dns-json")?)
-        .into_json_response::<serde_json::Value>()
-        .await?;
+        let (status, body) = ctx
+            .request(
+                Method::GET,
+                format!(
+                    "/dns-query?name={}&type={}",
+                    format_args!("_did.{}.localhost", username),
+                    "txt"
+                ),
+            )
+            .with_accept_mime(Mime::from_str("application/dns-json")?)
+            .into_json_response::<serde_json::Value>()
+            .await?;
 
         assert_eq!(status, StatusCode::OK);
         assert_eq!(

--- a/fission-server/src/routes/health.rs
+++ b/fission-server/src/routes/health.rs
@@ -101,7 +101,7 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_healthcheck_healthy() -> TestResult {
-        let ctx = TestContext::new().await;
+        let ctx = &TestContext::new().await?;
 
         let (status, body) =
             RouteBuilder::<DefaultFact>::new(ctx.app(), Method::GET, "/healthcheck")
@@ -117,7 +117,7 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_healthcheck_db_unavailable() -> TestResult {
-        let ctx = TestContext::new().await;
+        let ctx = TestContext::new().await?;
         let app = ctx.app();
 
         // Drop the database
@@ -136,13 +136,13 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_healthcheck_db_out_of_date() -> TestResult {
-        let ctx = TestContext::new().await;
-        let mut conn = ctx.get_db_conn().await;
+        let ctx = &TestContext::new().await?;
+        let conn = &mut ctx.get_db_conn().await?;
 
         // Insert a new migration at the end of time
         diesel::insert_into(__diesel_schema_migrations::table)
             .values(__diesel_schema_migrations::version.eq("2239-09-30-desolation".to_string()))
-            .execute(&mut conn)
+            .execute(conn)
             .await?;
 
         let (status, body) =

--- a/fission-server/src/routes/ping.rs
+++ b/fission-server/src/routes/ping.rs
@@ -26,7 +26,7 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_ping() -> TestResult {
-        let ctx = TestContext::new().await;
+        let ctx = &TestContext::new().await?;
 
         let (status, _) = RouteBuilder::<DefaultFact>::new(ctx.app(), Method::GET, "/ping")
             .into_raw_response()

--- a/fission-server/src/routes/ping.rs
+++ b/fission-server/src/routes/ping.rs
@@ -18,17 +18,16 @@ pub async fn get() -> AppResult<StatusCode> {
 
 #[cfg(test)]
 mod tests {
+    use crate::test_utils::test_context::TestContext;
     use http::{Method, StatusCode};
-    use rs_ucan::DefaultFact;
     use testresult::TestResult;
-
-    use crate::test_utils::{route_builder::RouteBuilder, test_context::TestContext};
 
     #[test_log::test(tokio::test)]
     async fn test_ping() -> TestResult {
         let ctx = &TestContext::new().await?;
 
-        let (status, _) = RouteBuilder::<DefaultFact>::new(ctx.app(), Method::GET, "/ping")
+        let (status, _) = ctx
+            .request(Method::GET, "/ping")
             .into_raw_response()
             .await?;
 

--- a/fission-server/src/routes/revocations.rs
+++ b/fission-server/src/routes/revocations.rs
@@ -37,7 +37,7 @@ pub async fn post_revocation<S: ServerSetup>(
 
 #[cfg(test)]
 mod tests {
-    use crate::test_utils::{route_builder::RouteBuilder, test_context::TestContext};
+    use crate::test_utils::test_context::TestContext;
     use fission_core::{
         capabilities::{did::Did, fission::FissionAbility},
         common::SuccessResponse,
@@ -47,7 +47,6 @@ mod tests {
     use http::{Method, StatusCode};
     use rs_ucan::{
         builder::UcanBuilder, capability::Capability, semantics::caveat::EmptyCaveat, ucan::Ucan,
-        DefaultFact,
     };
     use serde_json::Value;
     use testresult::TestResult;
@@ -69,12 +68,12 @@ mod tests {
 
         let revocation = Revocation::new(issuer, &ucan)?;
 
-        let (status, response) =
-            RouteBuilder::<DefaultFact>::new(ctx.app(), Method::POST, "/api/v0/revocations")
-                .with_json_body(&revocation)?
-                .with_ucan(ucan)
-                .into_json_response::<SuccessResponse>()
-                .await?;
+        let (status, response) = ctx
+            .request(Method::POST, "/api/v0/revocations")
+            .with_json_body(&revocation)?
+            .with_ucan(ucan)
+            .into_json_response::<SuccessResponse>()
+            .await?;
 
         assert_eq!(status, StatusCode::CREATED);
         assert!(response.success);
@@ -100,12 +99,12 @@ mod tests {
 
         let revocation = Revocation::new(issuer, &ucan)?;
 
-        let (status, _response) =
-            RouteBuilder::<DefaultFact>::new(ctx.app(), Method::POST, "/api/v0/revocations")
-                .with_json_body(&revocation)?
-                .with_ucan(ucan)
-                .into_json_response::<Value>()
-                .await?;
+        let (status, _response) = ctx
+            .request(Method::POST, "/api/v0/revocations")
+            .with_json_body(&revocation)?
+            .with_ucan(ucan)
+            .into_json_response::<Value>()
+            .await?;
 
         assert_eq!(status, StatusCode::FORBIDDEN);
 

--- a/fission-server/src/routes/revocations.rs
+++ b/fission-server/src/routes/revocations.rs
@@ -54,7 +54,7 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_post_revocation_ok() -> TestResult {
-        let ctx = TestContext::new().await;
+        let ctx = &TestContext::new().await?;
 
         let issuer = &EdDidKey::generate();
 
@@ -84,7 +84,7 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_post_revocation_of_foreign_forbidden() -> TestResult {
-        let ctx = TestContext::new().await;
+        let ctx = &TestContext::new().await?;
 
         let issuer = &EdDidKey::generate();
         let foreign = &EdDidKey::generate();

--- a/fission-server/src/setups/mod.rs
+++ b/fission-server/src/setups/mod.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 
 pub mod local;
 pub mod prod;
-#[cfg(test)]
+#[cfg(any(feature = "test_utils", test))]
 pub mod test;
 
 /// This trait groups type parameters to the server's `AppState` struct.

--- a/fission-server/src/test_utils/ephermeral_db.rs
+++ b/fission-server/src/test_utils/ephermeral_db.rs
@@ -1,0 +1,39 @@
+use anyhow::{anyhow, Context as _, Result};
+use diesel::{Connection, PgConnection, RunQueryDsl};
+
+pub fn create_ephermeral_db(database_url: &str, db_name: &str) -> Result<()> {
+    let postgres_url = format!("{}/postgres", database_url);
+
+    let conn = &mut PgConnection::establish(&postgres_url)?;
+
+    diesel::sql_query(&format!("CREATE DATABASE {}", db_name))
+        .execute(conn)
+        .map_err(|e| anyhow!(e))
+        .context(format!("Could not create database {}", db_name))?;
+
+    Ok(())
+}
+
+pub fn destroy_ephermeral_db(database_url: &str, db_name: &str) -> Result<()> {
+    let postgres_url = format!("{}/postgres", database_url);
+
+    let conn = &mut PgConnection::establish(&postgres_url)
+        .context("Cannot connect to postgres database.")?;
+
+    let disconnect_users = format!(
+        "SELECT pg_terminate_backend(pid)
+         FROM pg_stat_activity
+         WHERE datname = '{}';",
+        db_name
+    );
+
+    diesel::sql_query(&disconnect_users).execute(conn)?;
+
+    let query = diesel::sql_query(&format!("DROP DATABASE {}", db_name));
+
+    query
+        .execute(conn)
+        .context(format!("Could not drop database {}", db_name))?;
+
+    Ok(())
+}

--- a/fission-server/src/test_utils/ephermeral_db.rs
+++ b/fission-server/src/test_utils/ephermeral_db.rs
@@ -1,21 +1,40 @@
+//! Setup and destruction of an ephemeral DB for testing setups
+use crate::db::MIGRATIONS;
 use anyhow::{anyhow, Context as _, Result};
 use diesel::{Connection, PgConnection, RunQueryDsl};
+use diesel_migrations::MigrationHarness;
+use uuid::Uuid;
 
-pub fn create_ephermeral_db(database_url: &str, db_name: &str) -> Result<()> {
-    let postgres_url = format!("{}/postgres", database_url);
+/// Create a new ephemeral DB.
+pub fn create_ephermeral_db(base_url: &str, prefix: &str) -> Result<String> {
+    let db_name = format!("{prefix}_{}", Uuid::new_v4().simple());
+
+    tracing::debug!(?db_name, "Using ephemeral DB");
+
+    let postgres_url = format!("{}/postgres", base_url);
 
     let conn = &mut PgConnection::establish(&postgres_url)?;
 
-    diesel::sql_query(&format!("CREATE DATABASE {}", db_name))
+    diesel::sql_query(format!("CREATE DATABASE {}", &db_name))
         .execute(conn)
         .map_err(|e| anyhow!(e))
-        .context(format!("Could not create database {}", db_name))?;
+        .context(format!("Could not create database {}", &db_name))?;
 
-    Ok(())
+    let mut conn = PgConnection::establish(&format!("{}/{}", base_url, db_name))
+        .context("Cannot connect to postgres database.")?;
+
+    conn.run_pending_migrations(MIGRATIONS)
+        .map_err(|e| anyhow!(e))
+        .context("Could not run migrations")?;
+
+    Ok(db_name)
 }
 
-pub fn destroy_ephermeral_db(database_url: &str, db_name: &str) -> Result<()> {
-    let postgres_url = format!("{}/postgres", database_url);
+/// Destroy an ephemeral DB
+pub fn destroy_ephermeral_db(base_url: &str, db_name: &str) -> Result<()> {
+    tracing::debug!(?db_name, "Tearing down ephemeral DB");
+
+    let postgres_url = format!("{}/postgres", base_url);
 
     let conn = &mut PgConnection::establish(&postgres_url)
         .context("Cannot connect to postgres database.")?;
@@ -27,9 +46,9 @@ pub fn destroy_ephermeral_db(database_url: &str, db_name: &str) -> Result<()> {
         db_name
     );
 
-    diesel::sql_query(&disconnect_users).execute(conn)?;
+    diesel::sql_query(disconnect_users).execute(conn)?;
 
-    let query = diesel::sql_query(&format!("DROP DATABASE {}", db_name));
+    let query = diesel::sql_query(format!("DROP DATABASE {}", db_name));
 
     query
         .execute(conn)

--- a/fission-server/src/test_utils/mod.rs
+++ b/fission-server/src/test_utils/mod.rs
@@ -1,2 +1,3 @@
+pub mod ephermeral_db;
 pub mod route_builder;
 pub mod test_context;

--- a/fission-server/src/test_utils/mod.rs
+++ b/fission-server/src/test_utils/mod.rs
@@ -1,3 +1,6 @@
+//! Testing utilities. Some submodules are only enabled with the test_utils feature
 pub mod ephermeral_db;
+#[cfg(any(feature = "test_utils", test))]
 pub mod route_builder;
+#[cfg(any(feature = "test_utils", test))]
 pub mod test_context;

--- a/fission-server/src/test_utils/mod.rs
+++ b/fission-server/src/test_utils/mod.rs
@@ -1,2 +1,2 @@
-pub(crate) mod route_builder;
-pub(crate) mod test_context;
+pub mod route_builder;
+pub mod test_context;

--- a/fission-server/src/test_utils/route_builder.rs
+++ b/fission-server/src/test_utils/route_builder.rs
@@ -1,3 +1,4 @@
+//! Helpers for running requests
 use anyhow::{anyhow, Result};
 use axum::Router;
 use bytes::Bytes;

--- a/fission-server/src/test_utils/route_builder.rs
+++ b/fission-server/src/test_utils/route_builder.rs
@@ -9,7 +9,8 @@ use rs_ucan::{ucan::Ucan, DefaultFact};
 use serde::{de::DeserializeOwned, Serialize};
 use tower::ServiceExt;
 
-pub(crate) struct RouteBuilder<F = DefaultFact> {
+#[derive(Debug)]
+pub struct RouteBuilder<F = DefaultFact> {
     app: Router,
     method: Method,
     path: Uri,
@@ -20,7 +21,7 @@ pub(crate) struct RouteBuilder<F = DefaultFact> {
 }
 
 impl<F: Clone + DeserializeOwned> RouteBuilder<F> {
-    pub(crate) fn new<U>(app: Router, method: Method, path: U) -> Self
+    pub fn new<U>(app: Router, method: Method, path: U) -> Self
     where
         Uri: TryFrom<U>,
         <Uri as TryFrom<U>>::Error: Into<http::Error>,
@@ -36,29 +37,29 @@ impl<F: Clone + DeserializeOwned> RouteBuilder<F> {
         }
     }
 
-    pub(crate) fn with_ucan(mut self, ucan: Ucan<F>) -> Self {
+    pub fn with_ucan(mut self, ucan: Ucan<F>) -> Self {
         self.ucan = Some(ucan);
         self
     }
 
-    pub(crate) fn with_ucan_proof(mut self, ucan: Ucan) -> Self {
+    pub fn with_ucan_proof(mut self, ucan: Ucan) -> Self {
         self.ucan_proofs.extend(Some(ucan));
         self
     }
 
-    pub(crate) fn with_ucan_proofs(mut self, proofs: impl IntoIterator<Item = Ucan>) -> Self {
+    pub fn with_ucan_proofs(mut self, proofs: impl IntoIterator<Item = Ucan>) -> Self {
         for proof in proofs.into_iter() {
             self = self.with_ucan_proof(proof);
         }
         self
     }
 
-    pub(crate) fn with_accept_mime(mut self, accept_mime: Mime) -> Self {
+    pub fn with_accept_mime(mut self, accept_mime: Mime) -> Self {
         self.accept_mime = Some(accept_mime);
         self
     }
 
-    pub(crate) fn with_json_body<T>(mut self, body: T) -> Result<Self>
+    pub fn with_json_body<T>(mut self, body: T) -> Result<Self>
     where
         T: Serialize,
     {
@@ -69,7 +70,7 @@ impl<F: Clone + DeserializeOwned> RouteBuilder<F> {
         Ok(self)
     }
 
-    pub(crate) async fn into_raw_response(mut self) -> Result<(StatusCode, Bytes)> {
+    pub async fn into_raw_response(mut self) -> Result<(StatusCode, Bytes)> {
         let request = self.build_request()?;
         let response = self.app.oneshot(request).await?;
         let status = response.status();
@@ -78,7 +79,7 @@ impl<F: Clone + DeserializeOwned> RouteBuilder<F> {
         Ok((status, body))
     }
 
-    pub(crate) async fn into_json_response<T>(mut self) -> Result<(StatusCode, T)>
+    pub async fn into_json_response<T>(mut self) -> Result<(StatusCode, T)>
     where
         T: DeserializeOwned,
     {

--- a/fission-server/src/test_utils/test_context.rs
+++ b/fission-server/src/test_utils/test_context.rs
@@ -1,5 +1,4 @@
-use std::net::SocketAddr;
-
+//! Helpers for running isolated webserver instances
 use crate::{
     app_state::{AppState, AppStateBuilder},
     db::{self, Conn, MIGRATIONS},
@@ -8,14 +7,18 @@ use crate::{
     settings::Dns,
     setups::test::{TestIpfsDatabase, TestSetup, TestVerificationCodeSender},
 };
+use anyhow::{anyhow, Context, Result};
 use axum::{extract::connect_info::MockConnectInfo, Router};
 use axum_server::service::SendService;
 use diesel::{Connection, PgConnection, RunQueryDsl};
 use diesel_migrations::MigrationHarness;
 use fission_core::{ed_did_key::EdDidKey, username::Handle};
+use std::net::SocketAddr;
 use uuid::Uuid;
 
-pub(crate) struct TestContext {
+/// A reference to a running fission server in an isolated test environment
+#[derive(Debug)]
+pub struct TestContext {
     app: Router,
     app_state: AppState<TestSetup>,
     base_url: String,
@@ -23,11 +26,12 @@ pub(crate) struct TestContext {
 }
 
 impl TestContext {
-    pub(crate) async fn new() -> Self {
+    /// Create a new test context
+    pub async fn new() -> Result<Self> {
         Self::new_with_state(|builder| builder).await
     }
 
-    pub(crate) async fn new_with_state<F>(f: F) -> Self
+    pub async fn new_with_state<F>(f: F) -> Result<Self>
     where
         F: FnOnce(AppStateBuilder<TestSetup>) -> AppStateBuilder<TestSetup>,
     {
@@ -35,24 +39,23 @@ impl TestContext {
         let db_name = format!("fission_server_test_{}", Uuid::new_v4().simple());
         let postgres_url = format!("{}/postgres", base_url);
 
-        let mut conn =
-            PgConnection::establish(&postgres_url).expect("Cannot connect to postgres database.");
+        let mut conn = PgConnection::establish(&postgres_url)?;
 
         let query = diesel::sql_query(format!("CREATE DATABASE {}", db_name).as_str());
 
         query
             .execute(&mut conn)
-            .expect(format!("Could not create database {}", db_name).as_str());
+            .map_err(|e| anyhow!(e))
+            .context(format!("Could not create database {}", db_name))?;
 
         let mut conn = PgConnection::establish(&format!("{}/{}", base_url, db_name))
-            .expect("Cannot connect to postgres database.");
+            .context("Cannot connect to postgres database.")?;
 
         conn.run_pending_migrations(MIGRATIONS)
-            .expect("Could not run migrations");
+            .map_err(|e| anyhow!(e))
+            .context("Could not run migrations")?;
 
-        let db_pool = db::pool(format!("{}/{}", base_url, db_name).as_str(), 1)
-            .await
-            .unwrap();
+        let db_pool = db::pool(format!("{}/{}", base_url, db_name).as_str(), 1).await?;
 
         let dns_settings = Dns {
             server_port: 1053,
@@ -66,7 +69,7 @@ impl TestContext {
         let keypair = EdDidKey::generate();
 
         let dns_server = DnsServer::new(&dns_settings, db_pool.clone(), keypair.did())
-            .expect("Could not initialize DNS server");
+            .context("Could not initialize DNS server")?;
 
         let builder = AppStateBuilder::default()
             .with_dns_settings(dns_settings)
@@ -82,41 +85,41 @@ impl TestContext {
             .layer(MockConnectInfo(SocketAddr::from(([0, 0, 0, 0], 3000))))
             .into_service();
 
-        Self {
+        Ok(Self {
             app,
             app_state,
             base_url: base_url.to_string(),
             db_name: db_name.to_string(),
-        }
+        })
     }
 
-    pub(crate) fn app(&self) -> Router {
+    pub fn app(&self) -> Router {
         self.app.clone()
     }
 
-    pub(crate) async fn get_db_conn(&self) -> Conn<'_> {
-        self.app_state.db_pool.get().await.unwrap()
+    pub async fn get_db_conn(&self) -> Result<Conn<'_>> {
+        Ok(self.app_state.db_pool.get().await?)
     }
 
     #[allow(unused)]
-    pub(crate) fn ipfs_db(&self) -> &TestIpfsDatabase {
+    pub fn ipfs_db(&self) -> &TestIpfsDatabase {
         &self.app_state.ipfs_db
     }
 
-    pub(crate) fn verification_code_sender(&self) -> &TestVerificationCodeSender {
+    pub fn verification_code_sender(&self) -> &TestVerificationCodeSender {
         &self.app_state.verification_code_sender
     }
 
-    pub(crate) fn server_did(&self) -> &EdDidKey {
+    pub fn server_did(&self) -> &EdDidKey {
         &self.app_state.server_keypair
     }
 
-    pub(crate) fn app_state(&self) -> &AppState<TestSetup> {
+    pub fn app_state(&self) -> &AppState<TestSetup> {
         &self.app_state
     }
 
-    pub(crate) fn user_handle(&self, username: &str) -> Handle {
-        Handle::new(username, &self.app_state.dns_settings.users_origin).unwrap()
+    pub fn user_handle(&self, username: &str) -> Result<Handle> {
+        Handle::new(username, &self.app_state.dns_settings.users_origin)
     }
 }
 

--- a/fission-server/src/test_utils/test_context.rs
+++ b/fission-server/src/test_utils/test_context.rs
@@ -13,8 +13,11 @@ use axum_server::service::SendService;
 use diesel::{Connection, PgConnection, RunQueryDsl};
 use diesel_migrations::MigrationHarness;
 use fission_core::{ed_did_key::EdDidKey, username::Handle};
+use http::{Method, Uri};
 use std::net::SocketAddr;
 use uuid::Uuid;
+
+use super::route_builder::RouteBuilder;
 
 /// A reference to a running fission server in an isolated test environment
 #[derive(Debug)]
@@ -120,6 +123,14 @@ impl TestContext {
 
     pub fn user_handle(&self, username: &str) -> Result<Handle> {
         Handle::new(username, &self.app_state.dns_settings.users_origin)
+    }
+
+    pub fn request<U>(&self, method: Method, path: U) -> RouteBuilder
+    where
+        Uri: TryFrom<U>,
+        <Uri as TryFrom<U>>::Error: Into<http::Error>,
+    {
+        RouteBuilder::new(self.app(), method, path)
     }
 }
 


### PR DESCRIPTION
Main addition: Integration tests between the CLI and server in `fission-cli/tests/main.rs`.
Also:
- Add `--ephemeral-db` parameter to the server to use an ephemeral DB while running which is destroyed on close
- Add `--close-on-stdin-close` parameter to the server to enable listening on EOF in stdin and closing appropriately
- Add `--gen-key-if-needed` parameter to the server to enable writing a new key to the fs if there is none yet
- Added `--no-colors` CLI parameter to turn of colored output
- Added hidden `--key-seed` CLI parameter to enable isolating CLI tests
- Refactor server tests a bit. More `?` and less `&`, `TestContext::request` shorthand, etc.