### PR TITLE
fix: Use `ucans` as header key, allow it in CORS

### DIFF
--- a/fission-cli/src/cli.rs
+++ b/fission-cli/src/cli.rs
@@ -259,7 +259,7 @@ impl<'s> CliState<'s> {
         let request = self
             .server_request(Method::GET, "/api/v0/capabilities")?
             .bearer_auth(ucan.encode()?)
-            .header("ucan", encode_ucan_header(&proofs)?);
+            .header("ucans", encode_ucan_header(&proofs)?);
 
         let ucans_response: UcansResponse = request.send().await?.json().await?;
 
@@ -298,7 +298,7 @@ impl<'s> CliState<'s> {
         let response: AccountAndAuth = self
             .server_request(Method::POST, "/api/v0/account")?
             .bearer_auth(ucan.encode()?)
-            .header("ucan", encode_ucan_header(&proofs)?)
+            .header("ucans", encode_ucan_header(&proofs)?)
             .header(CONTENT_TYPE, "application/json")
             .json(&AccountCreationRequest {
                 email,
@@ -335,7 +335,7 @@ impl<'s> CliState<'s> {
         let response: AccountAndAuth = self
             .server_request(Method::POST, &format!("/api/v0/account/{account_did}/link"))?
             .bearer_auth(ucan.encode()?)
-            .header("ucan", encode_ucan_header(&proofs)?)
+            .header("ucans", encode_ucan_header(&proofs)?)
             .header(CONTENT_TYPE, "application/json")
             .json(&AccountLinkRequest {
                 code: code.trim().to_string(),
@@ -405,7 +405,7 @@ impl<'s> CliState<'s> {
                 let account: Account = self
                     .server_request(Method::GET, "/api/v0/account")?
                     .bearer_auth(ucan.encode()?)
-                    .header("ucan", encode_ucan_header(&chain)?)
+                    .header("ucans", encode_ucan_header(&chain)?)
                     .send()
                     .await?
                     .json()
@@ -481,7 +481,7 @@ impl<'s> CliState<'s> {
             &format!("/api/v0/account/username/{new_username}"),
         )?
         .bearer_auth(ucan.encode()?)
-        .header("ucan", encode_ucan_header(chain)?)
+        .header("ucans", encode_ucan_header(chain)?)
         .send()
         .await?;
 
@@ -493,7 +493,7 @@ impl<'s> CliState<'s> {
 
         self.server_request(Method::PATCH, &format!("/api/v0/account/handle/{handle}"))?
             .bearer_auth(ucan.encode()?)
-            .header("ucan", encode_ucan_header(chain)?)
+            .header("ucans", encode_ucan_header(chain)?)
             .send()
             .await?;
 
@@ -505,7 +505,7 @@ impl<'s> CliState<'s> {
 
         self.server_request(Method::DELETE, "/api/v0/account")?
             .bearer_auth(ucan.encode()?)
-            .header("ucan", encode_ucan_header(chain)?)
+            .header("ucans", encode_ucan_header(chain)?)
             .send()
             .await?;
 

--- a/fission-server/src/extract/authority.rs
+++ b/fission-server/src/extract/authority.rs
@@ -30,16 +30,18 @@ use fission_core::{
 // UCAN header //
 /////////////////
 
-struct UcanHeader(Vec<Ucan>);
+/// The `ucans` header
+#[derive(Debug)]
+pub struct UcansHeader(Vec<Ucan>);
 
-impl Header for UcanHeader {
+impl Header for UcansHeader {
     fn name() -> &'static HeaderName {
-        static UCAN_HEADER: HeaderName = HeaderName::from_static("ucan");
+        static UCAN_HEADER: HeaderName = HeaderName::from_static("ucans");
         static UCAN_HEADER_NAME: &HeaderName = &UCAN_HEADER;
         UCAN_HEADER_NAME
     }
 
-    fn decode<'i, I>(header_values: &mut I) -> Result<UcanHeader, headers::Error>
+    fn decode<'i, I>(header_values: &mut I) -> Result<UcansHeader, headers::Error>
     where
         I: Iterator<Item = &'i http::HeaderValue>,
     {
@@ -55,7 +57,7 @@ impl Header for UcanHeader {
                 let ucan_str = ucan_str.trim();
                 if ucan_str.is_empty() {
                     // This can be the case, since `"".split(",").collect() == vec![""]`.
-                    // Also catches cases where someone sets `ucan=,,<token>` or uses trailing commas.
+                    // Also catches cases where someone sets `ucans=,,<token>` or uses trailing commas.
                     // Per Postel's principle we're lenient in what we accept.
                     continue;
                 }
@@ -67,7 +69,7 @@ impl Header for UcanHeader {
             }
         }
 
-        Ok(UcanHeader(ucans))
+        Ok(UcansHeader(ucans))
     }
 
     fn encode<E>(&self, values: &mut E)
@@ -132,8 +134,8 @@ async fn do_extract_authority<F: Clone + DeserializeOwned>(
             MissingCredentials
         })?;
 
-    let TypedHeader(UcanHeader(proofs)) = parts
-        .extract::<TypedHeader<UcanHeader>>()
+    let TypedHeader(UcansHeader(proofs)) = parts
+        .extract::<TypedHeader<UcansHeader>>()
         .await
         .map_err(|e| {
             tracing::error!(?e, "Error while looking up ucans header value");

--- a/fission-server/src/middleware/logging.rs
+++ b/fission-server/src/middleware/logging.rs
@@ -139,7 +139,7 @@ impl RequestResponseLogger for Logger {
                         .map(|h| h.to_str().unwrap_or(NULL)),
                 ucan = parts
                     .headers
-                    .get("ucan")
+                    .get("ucans")
                     .map(|h| h.to_str().unwrap_or(NULL))
                     .unwrap_or(NULL)),
             _ => {
@@ -164,7 +164,7 @@ impl RequestResponseLogger for Logger {
                     }),
                 ucan = parts
                     .headers
-                    .get("ucan")
+                    .get("ucans")
                     .map(|h| h.to_str().unwrap_or(NULL))
                 )
             }

--- a/fission-server/src/router.rs
+++ b/fission-server/src/router.rs
@@ -2,7 +2,6 @@
 
 use crate::{
     app_state::AppState,
-    extract::authority::UcansHeader,
     middleware::logging::{log_request_response, DebugOnlyLogger, Logger},
     routes::{
         account, auth, capability_indexing, doh, fallback::notfound_404, health, ipfs, ping,
@@ -14,21 +13,13 @@ use axum::{
     routing::{delete, get, patch, post},
     Router,
 };
-use headers::Header;
 use tower_http::cors::{Any, CorsLayer};
 
 /// Setup main router for application.
 pub fn setup_app_router<S: ServerSetup + 'static>(app_state: AppState<S>) -> Router {
     let cors = CorsLayer::new()
-        // allow `GET`, `POST`, and `PUT` when accessing the resource
-        .allow_methods([http::Method::GET, http::Method::POST, http::Method::PUT])
-        .allow_headers([
-            http::header::AUTHORIZATION,
-            http::header::CONTENT_TYPE,
-            http::header::ACCEPT,
-            UcansHeader::name().clone(),
-        ])
-        // allow requests from any origin
+        .allow_methods(Any)
+        .allow_headers(Any)
         .allow_origin(Any);
 
     let mut router = Router::new()

--- a/fission-server/src/router.rs
+++ b/fission-server/src/router.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     app_state::AppState,
+    extract::authority::UcansHeader,
     middleware::logging::{log_request_response, DebugOnlyLogger, Logger},
     routes::{
         account, auth, capability_indexing, doh, fallback::notfound_404, health, ipfs, ping,
@@ -13,6 +14,7 @@ use axum::{
     routing::{delete, get, patch, post},
     Router,
 };
+use headers::Header;
 use tower_http::cors::{Any, CorsLayer};
 
 /// Setup main router for application.
@@ -24,6 +26,7 @@ pub fn setup_app_router<S: ServerSetup + 'static>(app_state: AppState<S>) -> Rou
             http::header::AUTHORIZATION,
             http::header::CONTENT_TYPE,
             http::header::ACCEPT,
+            UcansHeader::name().clone(),
         ])
         // allow requests from any origin
         .allow_origin(Any);

--- a/fission-server/src/test_utils/route_builder.rs
+++ b/fission-server/src/test_utils/route_builder.rs
@@ -118,7 +118,7 @@ impl<F: Clone + DeserializeOwned> RouteBuilder<F> {
             .collect::<Result<Vec<String>, _>>()?
             .join(", ");
         if !proofs_header.is_empty() {
-            builder = builder.header("ucan", proofs_header);
+            builder = builder.header("ucans", proofs_header);
         }
 
         if let Some((mime, body)) = self.body.take() {


### PR DESCRIPTION
Use the correct string for the header key, as per spec: https://github.com/ucan-wg/ucan-http-bearer-token#2-request-headers

Also set the header as allowed in the CORS settings.
